### PR TITLE
add install requirements to setup.cfg

### DIFF
--- a/emanifest-py/setup.cfg
+++ b/emanifest-py/setup.cfg
@@ -15,6 +15,10 @@ package_dir =
     = src
 packages = find:
 python_requires = >=3.6
+install_requires =
+    requests
+    requests_toolbelt
+    pandas
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
The additions to setup.cfg should mean that when emanifest is install with pip, it's non-standard library dependancies are automaticaly installed as well.