### PR TITLE
more fixes to emanifest-py

### DIFF
--- a/emanifest-py/README.md
+++ b/emanifest-py/README.md
@@ -43,10 +43,10 @@ Before using the **emanifest** package, ensure you have a RCRAInfo user account 
 All methods to access the e-Manifest APIs are implemented by the RcrainfoClient class which needs to be authenticated with your API ID and Key. A new instance of the class can be initiated with the ```new_client()``` convenience function like so:
 
 ```python
-from emanifest import emanifest
+from emanifest import client as em
 
-em = emanifest.new_client('preprod')
-em.Auth('YOUR_API_ID', 'YOUR_API_KEY')
+rcra_client = em.new_client('preprod')
+rcra_client.Auth('YOUR_API_ID', 'YOUR_API_KEY')
 ```
 
 ```new_client()``` accepts a string, either **preprod**, **prod**, or a complete base URL. To register for a testing account in preproduction, visit the [preprod site](https://rcrainfopreprod.epa.gov/rcrainfo/action/secured/login). The RcrainfoClient stores the JSON web token and its expiration period (20 minutes). Currently, the **emanifest** python package does not automatically reauthenticate.
@@ -71,17 +71,17 @@ Content will be returned as a RcraResponse object, which wraps around the [reque
 ### Exmaples:
 
 ```python
-em.GetSiteDetails('VATEST000001')
+rcra_client.GetSiteDetails('VATEST000001')
 ```
 Once you've confirmed this is the correct site, you might search for manifests in transit from that site:
 
 ```python
-em.SearchMTN(siteId='VATEST000001', status='InTransit')
+rcra_client.SearchMTN(siteId='VATEST000001', status='InTransit')
 ```
 If one of those manifests didn't match your records, you could initiate a correction with the correct JSON information and optionally any attachments (.zip):
 
 ```python
-em.Correct('manifest_file_name.json', 'optional_attachments.zip')
+rcra_client.Correct('manifest_file_name.json', 'optional_attachments.zip')
 ```
 
 ### Help

--- a/emanifest-py/setup.cfg
+++ b/emanifest-py/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = emanifest
-version = 2.0.1
+version = 2.0.2
 author = William Nicholas
 author_email = nicholas.william@epa.gov
 description = An API utility wrapper for accessing the e-Manifest hazardous waste tracking system maintained by the US Environmental Protection Agency

--- a/emanifest-py/src/emanifest/client.py
+++ b/emanifest-py/src/emanifest/client.py
@@ -15,17 +15,24 @@ class RcrainfoResponse:
     def __init__(self, response: requests.Response):
         self.response = response
         self.ok = response.ok
-        self.multipart_json = None
-        self.multipart_zip = None
+        self.json = None
+        self.zip = None
+
+    def __repr__(self):
+        return 'Object: RcrainfoResponse with status'.format(self.ok)
+
+    def ExtractAttributes(self):
+        self.ok = self.response.ok
+        self.json = self.response.json()
 
     def DecodeMultipart(self):
         multipart_data = decoder.MultipartDecoder.from_response(self.response)
         for part in multipart_data.parts:
             if part.headers[b'Content-Type'] == b'application/json':
-                self.multipart_json = part.text
+                self.json = part.text
             else:
                 zip_contents = zipfile.ZipFile(io.BytesIO(part.content))
-                self.multipart_zip = zip_contents
+                self.zip = zip_contents
 
 
 # noinspection PyIncorrectDocstring
@@ -34,6 +41,9 @@ class RcrainfoClient:
         self.base_url = base_url
         self.token = None
         self.token_expiration = None
+
+    def __repr__(self):
+        return 'Object: RcrainfoClient with base url {}'.format(self.base_url)
 
     def Auth(self, api_id, api_key):
         """
@@ -62,6 +72,7 @@ class RcrainfoClient:
         resp = RcrainfoResponse(requests.get(endpoint,
                                              headers={'Accept': 'application/json',
                                                       'Authorization': 'Bearer ' + self.token}))
+        resp.ExtractAttributes()
         return resp
 
     def __RCRAPost(self, endpoint, **kwargs):
@@ -69,21 +80,24 @@ class RcrainfoClient:
                                               headers={'Content-Type': 'text/plain', 'Accept': 'application/json',
                                                        'Authorization': 'Bearer ' + self.token},
                                               data=json.dumps(dict(**kwargs))))
+        resp.ExtractAttributes()
         return resp
 
     def __RCRADelete(self, endpoint):
         resp = RcrainfoResponse(requests.delete(endpoint,
                                                 headers={'Accept': 'application/json',
                                                          'Authorization': 'Bearer ' + self.token}))
+        resp.ExtractAttributes()
         return resp
 
     def __RCRAPut(self, endpoint, m):
         resp = RcrainfoResponse(requests.put(endpoint,
                                              headers={'Content-Type': m.content_type, 'Accept': 'application/json',
                                                       'Authorization': 'Bearer ' + self.token}, data=m))
+        resp.ExtractAttributes()
         return resp
 
-    def GetSiteDetails(self, epa_id):
+    def GetSiteDetails(self, epa_id) -> RcrainfoResponse:
         """
         Retrieve site details for a given Site ID
         
@@ -96,7 +110,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/site-details/' + epa_id
         return self.__RCRAGet(endpoint)
 
-    def GetHazardClasses(self):
+    def GetHazardClasses(self) -> RcrainfoResponse:
         """
         Retrieve all DOT Hazard Classes
         
@@ -106,7 +120,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/hazard-classes'
         return self.__RCRAGet(endpoint)
 
-    def GetPackingGroups(self):
+    def GetPackingGroups(self) -> RcrainfoResponse:
         """
         Retrieve all DOT Packing Groups
         
@@ -116,7 +130,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/packing-groups'
         return self.__RCRAGet(endpoint)
 
-    def GetHazClass_SN_ID(self, ship_name, id_num):
+    def GetHazClass_SN_ID(self, ship_name, id_num) -> RcrainfoResponse:
         """
         Retrieve DOT Hazard Classes by DOT Proper Shipping name and ID Number 
         
@@ -130,7 +144,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/hazard-class-by-shipping-name-id-number/' + ship_name + '/' + id_num
         return self.__RCRAGet(endpoint)
 
-    def GetPackGroups_SN_ID(self, ship_name, id_num):
+    def GetPackGroups_SN_ID(self, ship_name, id_num) -> RcrainfoResponse:
         """
         Retrieve DOT Packing Groups by DOT Proper Shipping name and ID Number 
         
@@ -144,7 +158,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/packing-groups-by-shipping-name-id-number/' + ship_name + '/' + id_num
         return self.__RCRAGet(endpoint)
 
-    def GetIDByShipName(self, ship_name):
+    def GetIDByShipName(self, ship_name) -> RcrainfoResponse:
         """
         Retrieve DOT ID number by DOT Proper Shipping name
         
@@ -157,7 +171,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/id-numbers-by-shipping-name/' + ship_name
         return self.__RCRAGet(endpoint)
 
-    def GetShipNameByID(self, id_num):
+    def GetShipNameByID(self, id_num) -> RcrainfoResponse:
         """
         Retrieve DOT Proper Shipping name by DOT ID number
         
@@ -170,7 +184,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/proper-shipping-names-by-id-number/' + id_num
         return self.__RCRAGet(endpoint)
 
-    def GetTNSuffix(self):
+    def GetTNSuffix(self) -> RcrainfoResponse:
         """
         Retrieve Allowable Manifest Tracking Number (MTN) Suffixes
 
@@ -180,7 +194,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/printed-tracking-number-suffixes'
         return self.__RCRAGet(endpoint)
 
-    def GetTNSuffixALL(self):
+    def GetTNSuffixALL(self) -> RcrainfoResponse:
         """
         Retrieve ALL Allowable Manifest Tracking Number (MTN) Suffixes
 
@@ -190,7 +204,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/printed-tracking-number-suffixes-ALL'
         return self.__RCRAGet(endpoint)
 
-    def GetContainerTypes(self):
+    def GetContainerTypes(self) -> RcrainfoResponse:
         """
         Retrieve Container Types
 
@@ -200,7 +214,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/container-types'
         return self.__RCRAGet(endpoint)
 
-    def GetQuantityUOM(self):
+    def GetQuantityUOM(self) -> RcrainfoResponse:
         """
         Retrieve Quantity Units of Measure (UOM)
 
@@ -210,7 +224,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/quantity-uom'
         return self.__RCRAGet(endpoint)
 
-    def GetLoadTypes(self):
+    def GetLoadTypes(self) -> RcrainfoResponse:
         """
         Retrieve PCB Load Types
 
@@ -220,7 +234,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/load-types'
         return self.__RCRAGet(endpoint)
 
-    def GetShippingNames(self):
+    def GetShippingNames(self) -> RcrainfoResponse:
         """
         Retrieve DOT Proper Shipping Names
 
@@ -230,7 +244,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/proper-shipping-names'
         return self.__RCRAGet(endpoint)
 
-    def GetIDNums(self):
+    def GetIDNums(self) -> RcrainfoResponse:
         """
         Retrieve DOT Shipping ID numbers
 
@@ -240,7 +254,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/lookup/id-numbers'
         return self.__RCRAGet(endpoint)
 
-    def GetDensityUOM(self):
+    def GetDensityUOM(self) -> RcrainfoResponse:
         """
         Retrieve Density Units of Measure (UOM)
 
@@ -250,7 +264,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/lookup/density-uom'
         return self.__RCRAGet(endpoint)
 
-    def GetFormCodes(self):
+    def GetFormCodes(self) -> RcrainfoResponse:
         """
         Retrieve Form Codes
 
@@ -260,7 +274,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/lookup/form-codes'
         return self.__RCRAGet(endpoint)
 
-    def GetSourceCodes(self):
+    def GetSourceCodes(self) -> RcrainfoResponse:
         """
         Retrieve Source Codes
 
@@ -270,7 +284,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/lookup/source-codes'
         return self.__RCRAGet(endpoint)
 
-    def GetStateWasteCodes(self, state_code):
+    def GetStateWasteCodes(self, state_code) -> RcrainfoResponse:
         """
         Retrieve State Waste Codes
 
@@ -280,7 +294,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/lookup/state-waste-codes/' + state_code
         return self.__RCRAGet(endpoint)
 
-    def GetFedWasteCodes(self):
+    def GetFedWasteCodes(self) -> RcrainfoResponse:
         """
         Retrieve Federal Waste Codes
 
@@ -290,7 +304,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/lookup/federal-waste-codes'
         return self.__RCRAGet(endpoint)
 
-    def GetManMethodCodes(self):
+    def GetManMethodCodes(self) -> RcrainfoResponse:
         """
         Retrieve Management Method Codes
 
@@ -300,7 +314,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/lookup/management-method-codes'
         return self.__RCRAGet(endpoint)
 
-    def GetWasteMinCodes(self):
+    def GetWasteMinCodes(self) -> RcrainfoResponse:
         """
         Retrieve Waste Minimization Codes
 
@@ -310,7 +324,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/lookup/waste-minimization-codes'
         return self.__RCRAGet(endpoint)
 
-    def GetPortsOfEntry(self):
+    def GetPortsOfEntry(self) -> RcrainfoResponse:
         """
         Retrieve Ports of Entry
 
@@ -320,7 +334,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/lookup/ports-of-entry'
         return self.__RCRAGet(endpoint)
 
-    def CheckSiteExists(self, site_id):
+    def CheckSiteExists(self, site_id) -> RcrainfoResponse:
         """
         Check if provided Site ID exists
                 
@@ -333,7 +347,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/site-exists/' + site_id
         return self.__RCRAGet(endpoint)
 
-    def SiteSearch(self, **kwargs):
+    def SiteSearch(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve sites based on some or all of the provided criteria
         
@@ -354,7 +368,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/site-search'
         return self.__RCRAPost(endpoint, **kwargs)
 
-    def GetBillingHistory(self, **kwargs):
+    def GetBillingHistory(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve billing history for a given billing account ID
         
@@ -369,7 +383,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/billing/bill-history'
         return self.__RCRAPost(endpoint, **kwargs)
 
-    def GetBill(self, **kwargs):
+    def GetBill(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve bill information for a given bill ID and account ID
         
@@ -384,7 +398,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/billing/bill'
         return self.__RCRAPost(endpoint, **kwargs)
 
-    def SearchBill(self, **kwargs):
+    def SearchBill(self, **kwargs) -> RcrainfoResponse:
         """
         Search and retrieve bills using all or some of the provided criteria
         
@@ -402,7 +416,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/billing/bill-search'
         return self.__RCRAPost(endpoint, **kwargs)
 
-    def GetAttachments(self, mtn):
+    def GetAttachments(self, mtn) -> RcrainfoResponse:
         """
         Retrieve e-Manifest details as json with attachments matching provided Manifest Tracking Number (MTN)
         
@@ -420,7 +434,7 @@ class RcrainfoClient:
             resp.DecodeMultipart()
         return resp
 
-    def SearchMTN(self, **kwargs):
+    def SearchMTN(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve manifest tracking numbers based on all or some of provided search criteria
         
@@ -439,7 +453,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/search'
         return self.__RCRAPost(endpoint, **kwargs)
 
-    def GetCorrectionDetails(self, mtn):
+    def GetCorrectionDetails(self, mtn) -> RcrainfoResponse:
         """
         Retrieve information about all manifest correction versions by manifest tracking number (MTN)
         
@@ -452,7 +466,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/manifest/correction-details/' + mtn
         return self.__RCRAGet(endpoint)
 
-    def GetCorrectionVersion(self, **kwargs):
+    def GetCorrectionVersion(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve details of manifest correction version based on all or some of the provided search criteria
 
@@ -468,7 +482,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/manifest/correction-version'
         return self.__RCRAPost(endpoint, **kwargs)
 
-    def GetMTNBySite(self, site_id):
+    def GetMTNBySite(self, site_id) -> RcrainfoResponse:
         """
         Retrieve manifest tracking numbers for a given Site ID
         
@@ -481,7 +495,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/manifest-tracking-numbers/' + site_id
         return self.__RCRAGet(endpoint)
 
-    def GetManByMTN(self, mtn):
+    def GetManByMTN(self, mtn) -> RcrainfoResponse:
         """
         Retrieve e-Manifest details matching provided Manifest Tracking Number (MTN)
         
@@ -494,7 +508,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/manifest/' + mtn
         return self.__RCRAGet(endpoint)
 
-    def GetSites(self, state_code, site_type):
+    def GetSites(self, state_code, site_type) -> RcrainfoResponse:
         """
         Retrieve site ids for provided criteria
         
@@ -508,7 +522,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/site-ids/' + state_code + '/' + site_type
         return self.__RCRAGet(endpoint)
 
-    def Correct(self, manifest_json, zip_file=None):
+    def Correct(self, manifest_json, zip_file=None) -> RcrainfoResponse:
         """
         Correct Manifest by providing e-Manifest JSON and optional Zip attachment
         
@@ -523,7 +537,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/manifest/correct'
         return self.__RCRAPut(endpoint, m)
 
-    def Revert(self, mtn):
+    def Revert(self, mtn) -> RcrainfoResponse:
         """
         Revert manifest in 'UnderCorrection' status to previous 'Corrected' or 'Signed' version
         
@@ -536,7 +550,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/manifest/revert/' + mtn
         return self.__RCRAGet(endpoint)
 
-    def GetCorrectionAttachments(self, **kwargs):
+    def GetCorrectionAttachments(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve attachments of corrected manifests based all or some of the provided search criteria
 
@@ -568,7 +582,7 @@ class RcrainfoClient:
         else:
             print('Error: ' + str(resp.json()['message']))
 
-    def CheckMTNExists(self, mtn):
+    def CheckMTNExists(self, mtn) -> RcrainfoResponse:
         """
         Check if Manifest Tracking Number (MTN) exists and return basic details
         
@@ -581,7 +595,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/manifest/mtn-exists/' + mtn
         return self.__RCRAGet(endpoint)
 
-    def Update(self, manifest_json, zip_file=None):
+    def Update(self, manifest_json, zip_file=None) -> RcrainfoResponse:
         """
         Update Manifest by providing e-Manifest JSON and optional Zip attachment
         
@@ -597,7 +611,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/manifest/update'
         return self.__RCRAPut(endpoint, m)
 
-    def Delete(self, mtn):
+    def Delete(self, mtn) -> RcrainfoResponse:
         """
         Delete selected manifest
         
@@ -610,7 +624,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/emanifest/manifest/delete/' + mtn
         return self.__RCRADelete(endpoint)
 
-    def Save(self, manifest_json, zip_file=None):
+    def Save(self, manifest_json, zip_file=None) -> RcrainfoResponse:
         """
         Save Manifest by providing e-Manifest JSON and optional Zip attachment
         
@@ -628,7 +642,7 @@ class RcrainfoClient:
                              data=m)
         return resp.json()
 
-    def GenerateUILink(self, **kwargs):
+    def GenerateUILink(self, **kwargs) -> RcrainfoResponse:
         """
         Generate link to the user interface (UI) of the RCRAInfo e-Manifest module
         
@@ -644,7 +658,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/links/emanifest'
         return self.__RCRAPost(endpoint, **kwargs)
 
-    def CMELookup(self, activity_location, agency_code, nrr_flag=True):
+    def CMELookup(self, activity_location, agency_code, nrr_flag=True) -> RcrainfoResponse:
         """
         Retrieve all lookups for specific activity location and agency code, including staff, focus area and sub-organization
         
@@ -672,7 +686,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/state/cme/evaluation/evaluation-indicators'
         return self.__RCRAGet(endpoint)
 
-    def CMETypes(self):
+    def CMETypes(self) -> RcrainfoResponse:
         """
         Retrieve all evaluation types
 
@@ -682,7 +696,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/state/cme/evaluation/evaluation-types'
         return self.__RCRAGet(endpoint)
 
-    def GetAttachmentsReg(self, mtn):
+    def GetAttachmentsReg(self, mtn) -> RcrainfoResponse:
         """
         Retrieve e-Manifest details as json with attachments matching provided Manifest Tracking Number (MTN)
         
@@ -701,7 +715,7 @@ class RcrainfoClient:
             resp.DecodeMultipart()
         return resp
 
-    def SearchMTNReg(self, **kwargs):
+    def SearchMTNReg(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve manifest tracking numbers based on all or some of provided search criteria
         
@@ -720,7 +734,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/state/emanifest/search'
         return self.__RCRAPost(endpoint, **kwargs)
 
-    def GetCorrectionDetailsReg(self, mtn):
+    def GetCorrectionDetailsReg(self, mtn) -> RcrainfoResponse:
         """
         Retrieve information about all manifest correction versions by manifest tracking number (MTN)
         
@@ -733,7 +747,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/state/emanifest/manifest/correction-details/' + mtn
         return self.__RCRAGet(endpoint)
 
-    def GetCorrectionVersionReg(self, **kwargs):
+    def GetCorrectionVersionReg(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve details of manifest correction version based on all or some of the provided search criteria
 
@@ -749,7 +763,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/state/emanifest/manifest/correction-version'
         return self.__RCRAPost(endpoint, **kwargs)
 
-    def GetMTNBySiteReg(self, site_id):
+    def GetMTNBySiteReg(self, site_id) -> RcrainfoResponse:
         """
         Retrieve manifest tracking numbers for a given Site ID
         
@@ -762,7 +776,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/state/emanifest/manifest-tracking-numbers/' + site_id
         return self.__RCRAGet(endpoint)
 
-    def GetManByMTNReg(self, mtn):
+    def GetManByMTNReg(self, mtn) -> RcrainfoResponse:
         """
         Retrieve e-Manifest details matching provided Manifest Tracking Number (MTN)
         
@@ -775,7 +789,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/state/emanifest/manifest/' + mtn
         return self.__RCRAGet(endpoint)
 
-    def GetSitesReg(self, state_code, site_type):
+    def GetSitesReg(self, state_code, site_type) -> RcrainfoResponse:
         """
         Retrieve site ids for provided criteria
         
@@ -789,7 +803,7 @@ class RcrainfoClient:
         endpoint = self.base_url + '/api/v1/state/emanifest/site-ids/' + state_code + '/' + site_type
         return self.__RCRAGet(endpoint)
 
-    def GetHandler(self, handler_id, details=False):
+    def GetHandler(self, handler_id, details=False) -> RcrainfoResponse:
         """
         Retrieve a list of handler source records (and optional details) for a specific handler ID
         

--- a/emanifest-py/src/example.py
+++ b/emanifest-py/src/example.py
@@ -11,8 +11,8 @@
 # RcrainfoResponse {
 #   response:       requests.Response
 #   ok:             requests.Response.ok
-#   multipart_json: string                  part of multipart/mixed response if applicable
-#   multipart_zip:  zipfile.ZipFile         part of multipart/mixed response if applicable
+#   json: string                  part of multipart/mixed response if applicable
+#   zip:  zipfile.ZipFile         part of multipart/mixed response if applicable
 # }
 
 import os
@@ -20,16 +20,28 @@ from emanifest import client as em
 
 
 def main():
+
+    # change this manifest tracking number to one associated with your site
+    mtn = '100032524ELC'
+
     eman = em.new_client('preprod')
     eman.Auth(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
 
-    # dot_numbers = eman.GetManMethodCodes()
-    # print(dot_numbers.response.json())
+    dot_numbers = eman.GetManMethodCodes()
+    # The Response can be accessed by calling the request.Response.json() method, or the json attribute for ease
+    print(dot_numbers.response.json())
+    print(dot_numbers.json)
 
-    manifest_response = eman.GetAttachments("000012345GBF")
+    # Get Manifest json
+    manifest = eman.GetManByMTN(mtn)
+    with open('manifest.json', 'wb') as file:
+        file.write(manifest.response.content)
+
+    manifest_response = eman.GetAttachments(mtn)
     if manifest_response.ok:
-        # manifest_response.multipart_zip.extractall()
-        print(manifest_response.multipart_json)
+        # uncommenting the below line will save a number of files to your working directory
+        # manifest_response.zip.extractall()
+        print(manifest_response.json)
 
 
 if __name__ == '__main__':

--- a/emanifest-py/src/example.py
+++ b/emanifest-py/src/example.py
@@ -14,7 +14,7 @@
 #   json: string                  part of multipart/mixed response if applicable
 #   zip:  zipfile.ZipFile         part of multipart/mixed response if applicable
 # }
-
+import json
 import os
 from emanifest import client as em
 
@@ -24,24 +24,38 @@ def main():
     # change this manifest tracking number to one associated with your site
     mtn = '100032524ELC'
 
-    eman = em.new_client('preprod')
-    eman.Auth(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
+    rcra_client = em.new_client('preprod')
+    rcra_client.Auth(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
 
-    dot_numbers = eman.GetManMethodCodes()
+    dot_numbers = rcra_client.GetManMethodCodes()
     # The Response can be accessed by calling the request.Response.json() method, or the json attribute for ease
+    # These should print the same json
     print(dot_numbers.response.json())
     print(dot_numbers.json)
 
     # Get Manifest json
-    manifest = eman.GetManByMTN(mtn)
-    with open('manifest.json', 'wb') as file:
-        file.write(manifest.response.content)
+    manifest = rcra_client.GetManByMTN(mtn)
+    print(manifest.json)
+    # uncommenting the below will save manifest to './manifest.json'
+    # if manifest.ok:
+    #     with open('manifest.json', 'wb') as file:
+    #         file.write(manifest.response.content)
 
-    manifest_response = eman.GetAttachments(mtn)
-    if manifest_response.ok:
-        # uncommenting the below line will save a number of files to your working directory
-        # manifest_response.zip.extractall()
-        print(manifest_response.json)
+    manifest_attachments = rcra_client.GetAttachments(mtn)
+    print(manifest_attachments.ok)
+    # uncommenting the below line will save a number of files to your working directory
+    # if manifest_attachments.ok:
+    #     manifest_attachments.zip.extractall()
+
+    # update the paper manifest with the path to .json and .zip file
+    update_resp = rcra_client.Update('example_update.json', 'example_update.zip')
+    print(update_resp.ok)
+
+    # or pass json as a string
+    with open('example_update.json') as f:
+        data = f.read() # data is a string containing the manifest json
+        update_resp = rcra_client.Update(data)
+        print(update_resp.ok)
 
 
 if __name__ == '__main__':

--- a/emanifest-py/src/test.py
+++ b/emanifest-py/src/test.py
@@ -7,6 +7,7 @@ import requests
 from emanifest import client
 
 
+# utility function used by most of the integration tests
 def new_client_and_auth():
     cl = client.new_client('preprod')
     cl.Auth(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
@@ -15,6 +16,7 @@ def new_client_and_auth():
 
 class EManTest(unittest.TestCase):
 
+    # test of initial state
     def test_bad_auth(self):
         rcra_client = client.new_client('preprod')
         rcra_client.Auth(os.getenv('RCRAINFO_API_ID'), 'a_bad_api_key')
@@ -29,10 +31,33 @@ class EManTest(unittest.TestCase):
         rcra_response = cl.GetSiteDetails('VATESTGEN001')
         self.assertIsNone(rcra_response.zip)
 
+    # Authentacious test
+    def test_bad_auth(self):
+        rcra_client = client.new_client('preprod')
+        rcra_client.Auth(os.getenv('RCRAINFO_API_ID'), 'a_bad_api_key')
+        self.assertIsNone(rcra_client.token)
+
     def test_if_token_is_string(self):
         cl = new_client_and_auth()
         self.assertEqual(type("string"), type(cl.token))
 
+    # RcrainfoResponse test
+    def test_extracted_response_json_matches(self):
+        cl = new_client_and_auth()
+        resp = cl.GetSiteDetails('VATESTGEN001')
+        self.assertEqual(resp.response.json(), resp.json, "response.json() and json do not match")
+
+    def test_decode_multipart_string(self):
+        cl = new_client_and_auth()
+        manifest_response = cl.GetAttachments("000012345GBF")
+        self.assertEqual(type(manifest_response.json), str)
+
+    def test_decode_multipart_zipfile(self):
+        cl = new_client_and_auth()
+        manifest_response = cl.GetAttachments("000012345GBF")
+        self.assertEqual(type(manifest_response.zip), zipfile.ZipFile)
+
+    # Specific method related testing
     def test_site_import(self):
         cl = new_client_and_auth()
         rcra_response = cl.GetSiteDetails('VATESTGEN001')
@@ -61,17 +86,6 @@ class EManTest(unittest.TestCase):
         cl = new_client_and_auth()
         manifest_response = cl.GetAttachments("000012345GBF")
         self.assertTrue(manifest_response.ok)
-
-    def test_decode_multipart_string(self):
-        cl = new_client_and_auth()
-        manifest_response = cl.GetAttachments("000012345GBF")
-        self.assertEqual(type(manifest_response.json), str)
-
-    def test_decode_multipart_zipfile(self):
-        cl = new_client_and_auth()
-        manifest_response = cl.GetAttachments("000012345GBF")
-        self.assertEqual(type(manifest_response.zip), zipfile.ZipFile)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/emanifest-py/src/test.py
+++ b/emanifest-py/src/test.py
@@ -6,43 +6,71 @@ import requests
 
 from emanifest import client
 
-cl = client.new_client('preprod')
-cl.Auth(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
 
-# test = cl.GetHandler('VATESTGEN001')
-# print(test)
+def new_client_and_auth():
+    cl = client.new_client('preprod')
+    cl.Auth(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
+    return cl
 
 
 class EManTest(unittest.TestCase):
+
+    def test_bad_auth(self):
+        rcra_client = client.new_client('preprod')
+        rcra_client.Auth(os.getenv('RCRAINFO_API_ID'), 'a_bad_api_key')
+        self.assertIsNone(rcra_client.token)
+
+    def test_client_token_state(self):
+        unauthorized_client = client.new_client('preprod')
+        self.assertIsNone(unauthorized_client.token)
+
+    def test_initial_zip_state(self):
+        cl = new_client_and_auth()
+        rcra_response = cl.GetSiteDetails('VATESTGEN001')
+        self.assertIsNone(rcra_response.zip)
+
     def test_if_token_is_string(self):
+        cl = new_client_and_auth()
         self.assertEqual(type("string"), type(cl.token))
 
     def test_site_import(self):
+        cl = new_client_and_auth()
         rcra_response = cl.GetSiteDetails('VATESTGEN001')
         site_details = rcra_response.response.json()
         self.assertEqual(site_details['epaSiteId'], "VATESTGEN001")
 
+    def test_extracted_response_json_matches(self):
+        cl = new_client_and_auth()
+        resp = cl.GetSiteDetails('VATESTGEN001')
+        self.assertEqual(resp.response.json(), resp.json, "response.json() and json do not match")
+
     def test_check_mtn_exits(self):
+        cl = new_client_and_auth()
         mtn = "100032934ELC"
         self.assertEqual(cl.CheckMTNExists(mtn).response.json()["manifestTrackingNumber"], mtn)
 
     def test_shipping_names(self):
+        cl = new_client_and_auth()
         self.assertIn("Acetal", cl.GetShippingNames().response.json())
 
     def test_dot_numbers(self):
+        cl = new_client_and_auth()
         self.assertIn("UN1088", cl.GetIDNums().response.json())
 
     def test_get_attachments(self):
+        cl = new_client_and_auth()
         manifest_response = cl.GetAttachments("000012345GBF")
         self.assertTrue(manifest_response.ok)
 
     def test_decode_multipart_string(self):
+        cl = new_client_and_auth()
         manifest_response = cl.GetAttachments("000012345GBF")
-        self.assertEqual(type(manifest_response.multipart_json), str)
+        self.assertEqual(type(manifest_response.json), str)
 
     def test_decode_multipart_zipfile(self):
+        cl = new_client_and_auth()
         manifest_response = cl.GetAttachments("000012345GBF")
-        self.assertEqual(type(manifest_response.multipart_zip), zipfile.ZipFile)
+        self.assertEqual(type(manifest_response.zip), zipfile.ZipFile)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@wiljnichepa These commits do a couple things including
1. add ability to pass JSON string (instead of just file path) to encode_manifest, useful if POSTing/PUTing JSON data from database instead of filesystem. the encode_manifest function is still kind of a ticking time bomb, future work. 
2. upgrade the testing to include more cases
3. fix a couple inconsistency in return types that were overlooked for a couple of method
4. add API methods return type hinting for better autocomplete/IDE experience

I've already incremented the version number in setup.cfg. Sorry to bug you about this, if you wouldn't mind submitting to PyPi when you get a chance. 