### PR TITLE
emanpy v3.0 boilerplate

### DIFF
--- a/emanifest-py/README.md
+++ b/emanifest-py/README.md
@@ -4,25 +4,30 @@
 ![PyPI](https://img.shields.io/pypi/v/emanifest)
 [![License: CC0-1.0](https://img.shields.io/badge/License-CC0_1.0-lightgrey.svg)](http://creativecommons.org/publicdomain/zero/1.0/)
 
-**emanifest** is a client library for accessing the e-Manifest REST APIs of the US Environmental Protection Agency's RCRAInfo national electronic hazardous waste management system.
+**emanifest** is a client library for accessing the e-Manifest REST APIs of the US Environmental Protection Agency's
+RCRAInfo national electronic hazardous waste management system.
 
-**Note:** The **emanifest** package was substantially refactored after version 1.1.0 and was released as a new major version at 2.0.0. Code relying on version 1.1.0 should not upgrade to version 2.0.0 of this package without refactoring.
+**Note:** The **emanifest** package was substantially refactored after version 1.1.0 and was released as a new major
+version at 2.0.0. Code relying on version 1.1.0 should not upgrade to version 2.0.0 of this package without refactoring.
 
 ## Contents
+
 - [Requirements](#requirements)
 - [Dependencies](#dependencies)
 - [Installation](#installation)
 - [Usage](#usage)
-  - [Getting Started](#getting-started)
-  - [Methods](#methods)
-  - [Help](#help)
+    - [Getting Started](#getting-started)
+    - [Methods](#methods)
+    - [Help](#help)
 - [Contact](#contact)
 - [License](LICENSE.txt)
 
 ## Requirements
+
 - Python 3.7
 
 ## Dependencies
+
 - requests
 - requests_toolbelt
 
@@ -38,22 +43,34 @@ pip install emanifest
 
 ### Getting Started
 
-Before using the **emanifest** package, ensure you have a RCRAInfo user account and the [necessary permissions](https://www.epa.gov/e-manifest/frequent-questions-about-e-manifest#user_question6) to generate an API ID and key.
+Before using the **emanifest** package, ensure you have a RCRAInfo user account and
+the [necessary permissions](https://www.epa.gov/e-manifest/frequent-questions-about-e-manifest#user_question6) to
+generate an API ID and key.
 
-All methods to access the e-Manifest APIs are implemented by the RcrainfoClient class which needs to be authenticated with your API ID and Key. A new instance of the class can be initiated with the ```new_client()``` convenience function like so:
+All methods to access the e-Manifest APIs are implemented by the RcrainfoClient class which needs to be authenticated
+with your API ID and Key. A new instance of the class can be initiated with the ```new_client()``` convenience function
+like so:
 
 ```python
-from emanifest import client as em
+from emanifest import new_client
 
-rcra_client = em.new_client('preprod')
+rcra_client = new_client('preprod')
 rcra_client.Auth('YOUR_API_ID', 'YOUR_API_KEY')
 ```
 
-```new_client()``` accepts a string, either **preprod**, **prod**, or a complete base URL. To register for a testing account in preproduction, visit the [preprod site](https://rcrainfopreprod.epa.gov/rcrainfo/action/secured/login). The RcrainfoClient stores the JSON web token and its expiration period (20 minutes). Currently, the **emanifest** python package does not automatically reauthenticate.
+```new_client()``` accepts a string, either **preprod**, **prod**, or a complete base URL. To register for a testing
+account in preproduction, visit the [preprod site](https://rcrainfopreprod.epa.gov/rcrainfo/action/secured/login). The
+RcrainfoClient stores the JSON web token and its expiration period (20 minutes). Currently, the **emanifest** python
+package does not automatically reauthenticate.
 
 ### Methods
 
-After authenticating, you are ready to use the full functionality of the **emanifest** package. An introductory example script can be found [here](src/example.py). The RcrainfoClient class exposes a method for each API endpoint in one of the 10 service catagories. For more information about these services, visit the Swagger page of your selected environment. ([PREPROD](https://rcrainfopreprod.epa.gov/rcrainfo/secured/swagger/), [PROD](https://rcrainfo.epa.gov/rcrainfoprod/secured/swagger/)). API endpoints designed for use by other groups, such as regulators or industry users, will return 'Access Denied' errors if you are not authorized to access these resources in RCRAInfo.
+After authenticating, you are ready to use the full functionality of the **emanifest** package. An introductory example
+script can be found [here](src/example.py). The RcrainfoClient class exposes a method for each API endpoint in one of
+the 10 service catagories. For more information about these services, visit the Swagger page of your selected
+environment. ([PREPROD](https://rcrainfopreprod.epa.gov/rcrainfo/secured/swagger/), [PROD](https://rcrainfo.epa.gov/rcrainfoprod/secured/swagger/)).
+API endpoints designed for use by other groups, such as regulators or industry users, will return 'Access Denied' errors
+if you are not authorized to access these resources in RCRAInfo.
 
 1. [All users] Authentication services
 2. [All users] e-Manifest Lookup Services
@@ -67,27 +84,46 @@ After authenticating, you are ready to use the full functionality of the **emani
 10. [Regulator users] Handler Services
 11. [Regulator users] User Services
 
-Content will be returned as a RcraResponse object, which wraps around the [requests.Response](https://pypi.org/project/requests/) object. Methods that download file attachments are decoded and returned in the ```RcrainfoResponse.multipart_json``` and ```RcrainfoResponse.multipart_zip``` when appropriate. The entire ```request.Response``` object is returned in ```RcrainfoResponse.response```. Methods that update, correct, or save manifests by uploading new .json and/or .zip files require a file path.
+Content will be returned as a RcraResponse object, which wraps around
+the [requests.Response](https://pypi.org/project/requests/) object. Methods that download file attachments are decoded
+and returned in the ```RcrainfoResponse.multipart_json``` and ```RcrainfoResponse.multipart_zip``` when appropriate. The
+entire ```request.Response``` object is returned in ```RcrainfoResponse.response```. Methods that update, correct, or
+save manifests by uploading new .json and/or .zip files require a file path.
 
 ### Examples:
 
 ```python
-rcra_client.GetSiteDetails('VATEST000001')
+from emanifest import RcrainfoClient
+
+rcrainfo = RcrainfoClient('preprod')
+rcrainfo.GetSiteDetails('VATEST000001')
 ```
+
 Once you've confirmed this is the correct site, you might search for manifests in transit from that site:
 
 ```python
-rcra_client.SearchMTN(siteId='VATEST000001', status='InTransit')
+from emanifest import RcrainfoClient
+
+rcrainfo = RcrainfoClient('preprod')
+rcrainfo.SearchMTN(siteId='VATEST000001', status='InTransit')
 ```
-If one of those manifests didn't match your records, you could initiate a correction with the correct JSON information and optionally any attachments (.zip):
+
+If one of those manifests didn't match your records, you could initiate a correction with the correct JSON information
+and optionally any attachments (.zip):
 
 ```python
-rcra_client.Correct('manifest_file_name.json', 'optional_attachments.zip')
+from emanifest import RcrainfoClient
+
+rcrainfo = RcrainfoClient('preprod')
+rcrainfo.Correct('manifest_file_name.json', 'optional_attachments.zip')
 ```
 
 ### Help
 
-If you are uncertain how to use a function, run help(em.FunctionName) in your Python environment. This will return a description of the function, any required inputs, and the formats of those inputs. For a list of all the functions contained in **emanifest** and additional information about this package, run help(emanifest) in your Python environment.
+If you are uncertain how to use a function, run help(em.FunctionName) in your Python environment. This will return a
+description of the function, any required inputs, and the formats of those inputs. For a list of all the functions
+contained in **emanifest** and additional information about this package, run help(emanifest) in your Python
+environment.
 
 ## Contact
 
@@ -95,4 +131,9 @@ Please direct questions to the EPA e-Manifest team at [USEPA/e-manifest](https:/
 
 ## Disclaimer
 
-The United States Environmental Protection Agency (EPA) GitHub project code is provided on an "as is" basis and the user assumes responsibility for its use. EPA has relinquished control of the information and no longer has responsibility to protect the integrity, confidentiality, or availability of the information. Any reference to specific commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply their endorsement, recommendation or favoring by EPA. The EPA seal and logo shall not be used in any manner to imply endorsement of any commercial product or activity by EPA or the United States Government.
+The United States Environmental Protection Agency (EPA) GitHub project code is provided on an "as is" basis and the user
+assumes responsibility for its use. EPA has relinquished control of the information and no longer has responsibility to
+protect the integrity, confidentiality, or availability of the information. Any reference to specific commercial
+products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply
+their endorsement, recommendation or favoring by EPA. The EPA seal and logo shall not be used in any manner to imply
+endorsement of any commercial product or activity by EPA or the United States Government.

--- a/emanifest-py/README.md
+++ b/emanifest-py/README.md
@@ -55,7 +55,7 @@ like so:
 from emanifest import new_client
 
 rcra_client = new_client('preprod')
-rcra_client.Auth('YOUR_API_ID', 'YOUR_API_KEY')
+rcra_client.auth('YOUR_API_ID', 'YOUR_API_KEY')
 ```
 
 ```new_client()``` accepts a string, either **preprod**, **prod**, or a complete base URL. To register for a testing

--- a/emanifest-py/pyproject.toml
+++ b/emanifest-py/pyproject.toml
@@ -1,18 +1,18 @@
 [project]
 name = "emanifest"
-version = "2.0.7"
+version = "3.0.0"
 description = "An API utility wrapper for accessing the e-Manifest hazardous waste tracking system maintainedby the US Environmental Protection Agency"
 readme = "README.md"
 authors = [
-    {name = "William Nicholas ", email = "nicholas.william@epa.gov"},
+    { name = "William Nicholas ", email = "nicholas.william@epa.gov" },
 ]
 maintainers = [
-    {name = "William Nicholas", email = "nicholas.william@epa.gov"},
-    {name = "David Graham", email = "graham.david@epa.gov"},
-    {name = "Scott Christian", email = "christian.scott@epa.gov"},
+    { name = "William Nicholas", email = "nicholas.william@epa.gov" },
+    { name = "David Graham", email = "graham.david@epa.gov" },
+    { name = "Scott Christian", email = "christian.scott@epa.gov" },
 ]
 
-license = {text = "CCO 1.0"}
+license = { text = "CCO 1.0" }
 requires-python = ">=3.7"
 dependencies = [
     "requests==2.28.1",

--- a/emanifest-py/pyproject.toml
+++ b/emanifest-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "emanifest"
-version = "3.0.0"
+version = "3.0.1"
 description = "An API utility wrapper for accessing the e-Manifest hazardous waste tracking system maintainedby the US Environmental Protection Agency"
 readme = "README.md"
 authors = [

--- a/emanifest-py/src/emanifest/__init__.py
+++ b/emanifest-py/src/emanifest/__init__.py
@@ -1,0 +1,1 @@
+from .client import new_client, RcrainfoClient, RcrainfoResponse

--- a/emanifest-py/src/example.py
+++ b/emanifest-py/src/example.py
@@ -14,18 +14,17 @@
 #   json: string                  part of multipart/mixed response if applicable
 #   zip:  zipfile.ZipFile         part of multipart/mixed response if applicable
 # }
-import json
 import os
+
 from emanifest import client as em
 
 
 def main():
-
     # change this manifest tracking number to one associated with your site
     mtn = '100032524ELC'
 
     rcra_client = em.new_client('preprod')
-    rcra_client.Auth(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
+    rcra_client.auth(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
 
     dot_numbers = rcra_client.GetManMethodCodes()
     # The Response can be accessed by calling the request.Response.json() method, or the json attribute for ease
@@ -53,7 +52,7 @@ def main():
 
     # or pass json as a string
     with open('example_update.json') as f:
-        data = f.read() # data is a string containing the manifest json
+        data = f.read()  # data is a string containing the manifest json
         update_resp = rcra_client.Update(data)
         print(update_resp.ok)
 

--- a/emanifest-py/src/test_client.py
+++ b/emanifest-py/src/test_client.py
@@ -2,11 +2,11 @@ import os
 import unittest
 import zipfile
 
-from emanifest import client
+from emanifest import new_client
 
 
 class TestEmanifestClient(unittest.TestCase):
-    rcra_client = client.new_client('preprod')
+    rcra_client = new_client('preprod')
 
     def setUp(self) -> None:
         api_id = os.getenv('RCRAINFO_API_ID')
@@ -59,7 +59,7 @@ class TestEmanifestClient(unittest.TestCase):
 
 
 class BadClient(unittest.TestCase):
-    rcra_client = client.new_client('preprod')
+    rcra_client = new_client('preprod')
 
     # test of initial state
     def test_bad_auth(self):
@@ -67,7 +67,7 @@ class BadClient(unittest.TestCase):
         self.assertIsNone(self.rcra_client.token)
 
     def test_client_token_state(self):
-        unauthorized_client = client.new_client('preprod')
+        unauthorized_client = new_client('preprod')
         self.assertIsNone(unauthorized_client.token)
 
 

--- a/emanifest-py/src/test_client.py
+++ b/emanifest-py/src/test_client.py
@@ -15,10 +15,10 @@ class TestEmanifestClient(unittest.TestCase):
             self.fail('API ID not found to test integration')
         elif not api_key:
             self.fail('API Key not found to test integration')
-        self.rcra_client.Auth(api_id, api_key)
+        self.rcra_client.auth(api_id, api_key)
 
     def test_initial_zip_state(self):
-        rcra_response = self.rcra_client.GetSiteDetails('VATESTGEN001')
+        rcra_response = self.rcra_client.get_site_details('VATESTGEN001')
         self.assertIsNone(rcra_response.zip)
 
     def test_if_token_is_string(self):
@@ -26,35 +26,35 @@ class TestEmanifestClient(unittest.TestCase):
 
     # RcrainfoResponse test
     def test_extracted_response_json_matches(self):
-        resp = self.rcra_client.GetSiteDetails('VATESTGEN001')
+        resp = self.rcra_client.get_site_details('VATESTGEN001')
         self.assertEqual(resp.response.json(), resp.json, "response.json() and json do not match")
 
     def test_decode_multipart_string(self):
-        manifest_response = self.rcra_client.GetAttachments("000012345GBF")
+        manifest_response = self.rcra_client.get_attachments("000012345GBF")
         self.assertEqual(type(manifest_response.json), str)
 
     def test_decode_multipart_zipfile(self):
-        manifest_response = self.rcra_client.GetAttachments("000012345GBF")
+        manifest_response = self.rcra_client.get_attachments("000012345GBF")
         self.assertEqual(type(manifest_response.zip), zipfile.ZipFile)
 
     # Specific method related testing
     def test_site_import(self):
-        rcra_response = self.rcra_client.GetSiteDetails('VATESTGEN001')
+        rcra_response = self.rcra_client.get_site_details('VATESTGEN001')
         site_details = rcra_response.response.json()
         self.assertEqual(site_details['epaSiteId'], "VATESTGEN001")
 
     def test_check_mtn_exits(self):
         mtn = "100032934ELC"
-        self.assertEqual(self.rcra_client.CheckMTNExists(mtn).response.json()["manifestTrackingNumber"], mtn)
+        self.assertEqual(self.rcra_client.check_mtn_exists(mtn).response.json()["manifestTrackingNumber"], mtn)
 
     def test_shipping_names(self):
-        self.assertIn("Acetal", self.rcra_client.GetShippingNames().response.json())
+        self.assertIn("Acetal", self.rcra_client.get_shipping_names().response.json())
 
     def test_dot_numbers(self):
-        self.assertIn("UN1088", self.rcra_client.GetIDNums().response.json())
+        self.assertIn("UN1088", self.rcra_client.get_id_nums().response.json())
 
     def test_get_attachments(self):
-        manifest_response = self.rcra_client.GetAttachments("000012345GBF")
+        manifest_response = self.rcra_client.get_attachments("000012345GBF")
         self.assertTrue(manifest_response.ok)
 
 
@@ -63,7 +63,7 @@ class BadClient(unittest.TestCase):
 
     # test of initial state
     def test_bad_auth(self):
-        self.rcra_client.Auth(os.getenv('RCRAINFO_API_ID'), 'a_bad_api_key')
+        self.rcra_client.auth(os.getenv('RCRAINFO_API_ID'), 'a_bad_api_key')
         self.assertIsNone(self.rcra_client.token)
 
     def test_client_token_state(self):


### PR DESCRIPTION
## New Branch
We're creating a new branch in USEPA/e-Manifest called `emanpy_v3.0` that we'll merge into main whenever we're 100% sure that version 3.0 is ready and all our breaking changes are consolidated :)

## PR contents
This PR completes a lot of the boilerplate that we talked about the other day for emanifest PyPI package version 3.0. 

* fix import paths (e.g., `from emanifest import RcrainfoClient` instead of `from emanifest.client import RcrainfoClient`
* rename methods to snake_case instead of pascal case
* Some other misc stuff like use python's f-strings instead of concatenating string with the `+` operator, convert some instance attributes to properties and remove the unnecessary extract_attributes method
    * This last point is certainly up for debate if we feel it is not where we want to go for the 3.0 release.  