### PR TITLE
Rcrainfo client proposed changes

### DIFF
--- a/emanifest-py/README.md
+++ b/emanifest-py/README.md
@@ -8,7 +8,8 @@
 RCRAInfo national electronic hazardous waste management system.
 
 **Note:** The **emanifest** package was substantially refactored after version 2.0.7 and was released as a new major
-version at 3.0.1. Code relying on versions ≤3.0.0 should not upgrade to version 3.0.1 of this package without refactoring.
+version at 3.0.0. Code relying on versions ≤3.0.0 should not upgrade to version 3.0.0 of this package without
+refactoring.
 
 ## Contents
 
@@ -47,27 +48,38 @@ Before using the **emanifest** package, ensure you have a RCRAInfo user account 
 the [necessary permissions](https://www.epa.gov/e-manifest/frequent-questions-about-e-manifest#user_question6) to
 generate an API ID and key.
 
-All methods to access the e-Manifest APIs are implemented by the RcrainfoClient class which needs to be authenticated
-with your API ID and Key. A new instance of the class can be initiated with the ```new_client()``` convenience function
+All methods to access the e-Manifest APIs are implemented by the `RcrainfoClient` class which needs to be authenticated
+with your API ID and Key. A new instance of the class can be initiated with the `new_client()` convenience function
 like so:
 
 ```python
 from emanifest import new_client
 
-rcra_client = new_client('preprod')
-rcra_client.auth('YOUR_API_ID', 'YOUR_API_KEY')
+rcrainfo = new_client('preprod')
+rcrainfo.auth('YOUR_API_ID', 'YOUR_API_KEY')
 ```
 
-```new_client()``` accepts a string, either **preprod**, **prod**, or a complete base URL. To register for a testing
+which is equivalent to:
+
+```python
+from emanifest import RcrainfoClient
+
+rcrainfo = RcrainfoClient('preprod')
+rcrainfo.auth('YOUR_API_ID', 'YOUR_API_KEY')
+```
+
+`new_client()` accepts a string, either **preprod**, **prod**, or a complete base URL. To register for a testing
 account in preproduction, visit the [preprod site](https://rcrainfopreprod.epa.gov/rcrainfo/action/secured/login). The
 RcrainfoClient stores the JSON web token and its expiration period (20 minutes). Currently, the **emanifest** python
-package does not automatically reauthenticate.
+package does not automatically reauthenticate. See
+the [`RcrainfoClient` definition here](/emanifest-py/src/emanifest/client.py) for more details.
 
 ### Methods
 
-After authenticating, you are ready to use the full functionality of the **emanifest** package. An introductory example
+After authenticating, you are ready to use the full functionality of the emanifest package. An introductory example
 script can be found [here](src/example.py). The RcrainfoClient class exposes a method for each API endpoint in one of
-the 10 service catagories. For more information about these services, visit the Swagger page of your selected
+the 10 service categories (the [methods can be viewed here](/emanifest-py/src/emanifest/client.py)). For more
+information about these services, visit the Swagger page of your selected
 environment. ([PREPROD](https://rcrainfopreprod.epa.gov/rcrainfo/secured/swagger/), [PROD](https://rcrainfo.epa.gov/rcrainfoprod/secured/swagger/)).
 API endpoints designed for use by other groups, such as regulators or industry users, will return 'Access Denied' errors
 if you are not authorized to access these resources in RCRAInfo.
@@ -85,7 +97,7 @@ if you are not authorized to access these resources in RCRAInfo.
 11. [Regulator users] User Services
 
 Content will be returned as a RcraResponse object, which wraps around
-the [requests.Response](https://pypi.org/project/requests/) object. Methods that download file attachments are decoded
+the [requests](https://pypi.org/project/requests/) Response object. Methods that download file attachments are decoded
 and returned in the ```RcrainfoResponse.multipart_json``` and ```RcrainfoResponse.multipart_zip``` when appropriate. The
 entire ```request.Response``` object is returned in ```RcrainfoResponse.response```. Methods that update, correct, or
 save manifests by uploading new .json and/or .zip files require a file path.
@@ -96,7 +108,7 @@ save manifests by uploading new .json and/or .zip files require a file path.
 from emanifest import new_client
 
 rcrainfo = new_client('preprod')
-rcra_client.auth('YOUR_API_ID', 'YOUR_API_KEY')
+rcrainfo.auth('YOUR_API_ID', 'YOUR_API_KEY')
 
 rcrainfo.get_site_details('VATEST000001')
 ```
@@ -107,19 +119,21 @@ Once you've confirmed this is the correct site, you might search for manifests i
 from emanifest import new_client
 
 rcrainfo = new_client('preprod')
-rcra_client.auth('YOUR_API_ID', 'YOUR_API_KEY')
+rcrainfo.auth('YOUR_API_ID', 'YOUR_API_KEY')
 
 rcrainfo.search_mtn(siteId='VATEST000001', status='InTransit')
 ```
 
-If one of those manifests didn't match your records, you could initiate a correction with the correct JSON information
+Note, the keyword arguments use the same naming convention as the JSON RCRAInfo expects. If one of those manifests
+didn't match your records, you could initiate a
+correction with the correct JSON information
 and optionally any attachments (.zip):
 
 ```python
 from emanifest import new_client
 
 rcrainfo = new_client('preprod')
-rcra_client.auth('YOUR_API_ID', 'YOUR_API_KEY')
+rcrainfo.auth('YOUR_API_ID', 'YOUR_API_KEY')
 
 rcrainfo.correct('manifest_file_name.json', 'optional_attachments.zip')
 ```

--- a/emanifest-py/pyproject.toml
+++ b/emanifest-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "emanifest"
-version = "3.0.1"
+version = "3.0.0"
 description = "An API utility wrapper for accessing the e-Manifest hazardous waste tracking system maintainedby the US Environmental Protection Agency"
 readme = "README.md"
 authors = [

--- a/emanifest-py/src/emanifest/client.py
+++ b/emanifest-py/src/emanifest/client.py
@@ -442,7 +442,7 @@ class RcrainfoClient:
         """
         Retrieve sites based on some or all of the provided criteria
         
-        Args:
+        Keyword Args:
             epaSiteId (str): EPA site ID
             name (str): Site name (e.g. The White House)
             streetNumber (str): Street number (e.g. 1600)
@@ -464,7 +464,7 @@ class RcrainfoClient:
         Retrieve users based on some or all of the provided criteria. Only users of sites accessible
         to the API keyholder will be visible
         
-        Args:
+        Keyword Args:
             userId (str) : A RCRAInfo username
             siteIds (array of strings) : One or more EPA site IDs
             pageNumber (number): must be greater than 0
@@ -479,7 +479,7 @@ class RcrainfoClient:
         """
         Retrieve billing history for a given billing account ID
         
-        Args:
+        Keyword Args:
             billing_account (str): EPA Site ID
             start_month_year (date): First bill to be included (MM/YYYY format)
             end_month_year (date): Final bill to be included (MM/YYYY format)
@@ -494,7 +494,7 @@ class RcrainfoClient:
         """
         Retrieve bill information for a given bill ID and account ID
         
-        Args:
+        Keyword Args:
             billId (str): Bill ID
             billingAccount (str): EPA Site ID
             monthYear (date): Billing month (as MM/YYYY). Optional if billId is provided
@@ -509,7 +509,7 @@ class RcrainfoClient:
         """
         Search and retrieve bills using all or some of the provided criteria
         
-        Args:
+        Keyword Args:
             billingAccount (str): EPA Site ID
             billStatus (str): Active, Paid, Unpaid, ReadyForPayment, Credit, InProgress, SendToCollections, ZeroBalance.
             startDate(date): Beginning of the billing period (yyyy-MM-dd'T'HH:mm:ssZ or yyyy-MM-dd'T'HH:mm:ss.SSSZ)
@@ -545,7 +545,7 @@ class RcrainfoClient:
         """
         Retrieve manifest tracking numbers based on all or some of provided search criteria
         
-        Args:
+        Keyword Args:
             stateCode (str): Two-letter US postal state code
             siteId (str): EPA Site ID
             status (str): Pending, Scheduled, InTransit, Received, ReadyForSignature, Signed, SignedComplete,
@@ -578,7 +578,7 @@ class RcrainfoClient:
         """
         Retrieve details of manifest correction version based on all or some of the provided search criteria
 
-        Args:
+        Keyword Args:
             manifestTrackingNumber (str): Manifest tracking number. Required
             status (str): Manifest status (Signed, Corrected, UnderCorrection). Case-sensitive
             ppcStatus (str): EPA Paper Processing Center Status (PendingDataEntry, DataQaCompleted). Case-sensitive
@@ -743,7 +743,7 @@ class RcrainfoClient:
         """
         Generate link to the user interface (UI) of the RCRAInfo e-Manifest module
         
-        Args:
+        Keyword Args:
             page (str): Dashboard, BulkSign, BulkQuickSign, Edit, View, Sign. Case-sensitive
             epaSiteId (Str): EPA Site ID
             manifestTrackingNumber (str): Manifest tracking number (optional)
@@ -820,7 +820,7 @@ class RcrainfoClient:
         """
         Retrieve manifest tracking numbers based on all or some of provided search criteria
         
-        Args:
+        Keyword Args:
             stateCode (str): Two-letter US postal state code
             siteId (str): EPA Site ID
             status (str): Pending, Scheduled, InTransit, Received, ReadyForSignature, Signed, SignedComplete,
@@ -853,7 +853,7 @@ class RcrainfoClient:
         """
         Retrieve details of manifest correction version based on all or some of the provided search criteria
 
-        Args:
+        Keyword Args:
             manifestTrackingNumber (str): Manifest tracking number. Required
             status (str): Manifest status (Signed, Corrected, UnderCorrection). Case-sensitive
             ppcStatus (str): EPA Paper Processing Center Status (PendingDataEntry, DataQaCompleted). Case-sensitive

--- a/emanifest-py/src/example.py
+++ b/emanifest-py/src/example.py
@@ -23,37 +23,37 @@ def main():
     # change this manifest tracking number to one associated with your site
     mtn = '100032524ELC'
 
-    rcra_client = new_client('preprod')
-    rcra_client.auth(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
+    rcrainfo = new_client('preprod')
+    rcrainfo.auth(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
 
-    dot_numbers = rcra_client.get_man_method_codes()
+    dot_numbers = rcrainfo.get_man_method_codes()
     # The Response can be accessed by calling the request.Response.json() method, or the json attribute for ease
     # These should print the same json
     print(dot_numbers.response.json())
     print(dot_numbers.json)
 
     # Get Manifest json
-    manifest = rcra_client.get_man_by_mtn(mtn)
+    manifest = rcrainfo.get_man_by_mtn(mtn)
     print(manifest.json)
     # uncommenting the below will save manifest to './manifest.json'
     # if manifest.ok:
     #     with open('manifest.json', 'wb') as file:
     #         file.write(manifest.response.content)
 
-    manifest_attachments = rcra_client.get_attachments(mtn)
+    manifest_attachments = rcrainfo.get_attachments(mtn)
     print(manifest_attachments.ok)
     # uncommenting the below line will save a number of files to your working directory
     # if manifest_attachments.ok:
     #     manifest_attachments.zip.extractall()
 
     # update the paper manifest with the path to .json and .zip file
-    update_resp = rcra_client.update('example_update.json', 'example_update.zip')
+    update_resp = rcrainfo.update('example_update.json', 'example_update.zip')
     print(update_resp.ok)
 
     # or pass json as a string
     with open('example_update.json') as f:
         data = f.read()  # data is a string containing the manifest json
-        update_resp = rcra_client.update(data)
+        update_resp = rcrainfo.update(data)
         print(update_resp.ok)
 
 

--- a/emanifest-py/src/test_client.py
+++ b/emanifest-py/src/test_client.py
@@ -2,69 +2,108 @@ import os
 import unittest
 import zipfile
 
+import emanifest
 from emanifest import new_client
 
 
 class TestEmanifestClient(unittest.TestCase):
-    rcra_client = new_client('preprod')
+    rcrainfo = new_client('preprod')
 
     def setUp(self) -> None:
         api_id = os.getenv('RCRAINFO_API_ID')
         api_key = os.getenv('RCRAINFO_API_KEY')
+        print(api_key)
+        print(api_id)
         if not api_id:
             self.fail('API ID not found to test integration')
         elif not api_key:
             self.fail('API Key not found to test integration')
-        self.rcra_client.auth(api_id, api_key)
+        self.rcrainfo.auth(api_id, api_key)
 
     def test_initial_zip_state(self):
-        rcra_response = self.rcra_client.get_site_details('VATESTGEN001')
+        rcra_response = self.rcrainfo.get_site_details('VATESTGEN001')
         self.assertIsNone(rcra_response.zip)
 
     def test_if_token_is_string(self):
-        self.assertEqual(type("string"), type(self.rcra_client.token))
+        self.assertEqual(type("string"), type(self.rcrainfo.token))
 
     # RcrainfoResponse test
     def test_extracted_response_json_matches(self):
-        resp = self.rcra_client.get_site_details('VATESTGEN001')
+        resp = self.rcrainfo.get_site_details('VATESTGEN001')
         self.assertEqual(resp.response.json(), resp.json, "response.json() and json do not match")
 
     def test_decode_multipart_string(self):
-        manifest_response = self.rcra_client.get_attachments("000012345GBF")
+        manifest_response = self.rcrainfo.get_attachments("000012345GBF")
         self.assertEqual(type(manifest_response.json), str)
 
     def test_decode_multipart_zipfile(self):
-        manifest_response = self.rcra_client.get_attachments("000012345GBF")
+        manifest_response = self.rcrainfo.get_attachments("000012345GBF")
         self.assertEqual(type(manifest_response.zip), zipfile.ZipFile)
 
     # Specific method related testing
     def test_site_import(self):
-        rcra_response = self.rcra_client.get_site_details('VATESTGEN001')
+        rcra_response = self.rcrainfo.get_site_details('VATESTGEN001')
         site_details = rcra_response.response.json()
         self.assertEqual(site_details['epaSiteId'], "VATESTGEN001")
 
     def test_check_mtn_exits(self):
         mtn = "100032934ELC"
-        self.assertEqual(self.rcra_client.check_mtn_exists(mtn).response.json()["manifestTrackingNumber"], mtn)
+        self.assertEqual(self.rcrainfo.check_mtn_exists(mtn).response.json()["manifestTrackingNumber"], mtn)
 
     def test_shipping_names(self):
-        self.assertIn("Acetal", self.rcra_client.get_shipping_names().response.json())
+        self.assertIn("Acetal", self.rcrainfo.get_shipping_names().response.json())
 
     def test_dot_numbers(self):
-        self.assertIn("UN1088", self.rcra_client.get_id_nums().response.json())
+        self.assertIn("UN1088", self.rcrainfo.get_id_nums().response.json())
 
     def test_get_attachments(self):
-        manifest_response = self.rcra_client.get_attachments("000012345GBF")
+        manifest_response = self.rcrainfo.get_attachments("000012345GBF")
         self.assertTrue(manifest_response.ok)
 
 
+class TestRcrainfoClientIsExtendable:
+    class MyClass(emanifest.RcrainfoClient):
+        mock_api_id_from_external = 'an_api_id_from_someplace_else'
+        mock_api_key_from_external = 'a_api_key_from_someplace_else'
+
+        def retrieve_id(self, api_id=None) -> str:
+            """
+            This example method on our test subclass shows we can override the set_api_id method
+            if the user wants to get their api ID from somewhere else (e.g., a service, or database)
+            """
+            returned_string = self.mock_api_id_from_external  # You could get this primitive value from anywhere
+            return super().retrieve_id(returned_string)
+
+        def retrieve_key(self, api_key=None) -> str:
+            """
+            This example method on our test subclass shows we can override the set_api_key method
+            """
+            returned_string = self.mock_api_key_from_external  # You could get this primitive value from anywhere
+            return super().retrieve_id(returned_string)
+
+    def test_set_api_id_override(self):
+        my_subclass = self.MyClass('preprod')
+        api_id_set_during_auth = my_subclass.retrieve_id()
+        assert api_id_set_during_auth == self.MyClass.mock_api_id_from_external
+
+    def test_set_api_key_override(self):
+        my_subclass = self.MyClass('preprod')
+        api_key_set_during_auth = my_subclass.retrieve_key()
+        assert api_key_set_during_auth == self.MyClass.mock_api_key_from_external
+
+    def test_set_api_id_method(self):
+        my_subclass = self.MyClass('preprod')
+        api_key_set_during_auth = my_subclass.retrieve_key()
+        assert api_key_set_during_auth == self.MyClass.mock_api_key_from_external
+
+
 class BadClient(unittest.TestCase):
-    rcra_client = new_client('preprod')
+    bad_rcrainfo = new_client('preprod')
 
     # test of initial state
     def test_bad_auth(self):
-        self.rcra_client.auth(os.getenv('RCRAINFO_API_ID'), 'a_bad_api_key')
-        self.assertIsNone(self.rcra_client.token)
+        self.bad_rcrainfo.auth(os.getenv('RCRAINFO_API_ID'), 'a_bad_api_key')
+        self.assertIsNone(self.bad_rcrainfo.token)
 
     def test_client_token_state(self):
         unauthorized_client = new_client('preprod')

--- a/emanifest-py/src/test_client.py
+++ b/emanifest-py/src/test_client.py
@@ -60,6 +60,10 @@ class TestEmanifestClient(unittest.TestCase):
         manifest_response = self.rcrainfo.get_attachments("000012345GBF")
         self.assertTrue(manifest_response.ok)
 
+    def test_correction_get_attachments(self):
+        manifest_response = self.rcrainfo.get_correction_attachments(manifestTrackingNumber="000012345GBF")
+        self.assertTrue(manifest_response.ok)
+
 
 class TestRcrainfoClientIsExtendable:
     class MyClass(emanifest.RcrainfoClient):


### PR DESCRIPTION
## non-comprehensive proposed changes to the RcrainfoClient

This PR intends to trim the fat in RcrainfoClient and take advantage of the lower level tools made available via the `requests` library and clean up the RcrainfoClient's public vs private API.

* Converts the various internal __rcra_<request_method> methods with a __rcra_request method that prepares a `Request` and sends it using the requests library `Session` API. Supposedly this should result in performance gains but I don't have any metrics. More importantly, it makes our class more DRY, and we can now introduce features such as the ability to automatically re-authenticate after token expiration. We could also do things like pre/post request hooks that allow users of the package to execute custom code (e.g., logging).
* It makes a couple RcrainfoClient instance attributes private and gives the user properties to access them where appropriate. 
    * These could be expanded, and a another look at what attributes should be private could be beneficial.
* Adds a couple methods `retrieve_id` and `retrieve_key` which allow uses to write custom code to retrieve their API credentials from an external source like a database or external service.
    * I'm not sure if there's a better, more pythonic, way to do this. 

@wiljnichepa  let me know what you think, not all changes need to be incorporated. I can expand on things in a few hours. 

Edit: this PR should close #1519 