### PR TITLE
Sublclass requests.Session and auto authentication

### DIFF
--- a/emanifest-py/README.md
+++ b/emanifest-py/README.md
@@ -56,7 +56,7 @@ like so:
 from emanifest import new_client
 
 rcrainfo = new_client('preprod')
-rcrainfo.auth('YOUR_API_ID', 'YOUR_API_KEY')
+rcrainfo.authenticate('YOUR_API_ID', 'YOUR_API_KEY')
 ```
 
 which is equivalent to:
@@ -65,7 +65,7 @@ which is equivalent to:
 from emanifest import RcrainfoClient
 
 rcrainfo = RcrainfoClient('preprod')
-rcrainfo.auth('YOUR_API_ID', 'YOUR_API_KEY')
+rcrainfo.authenticate('YOUR_API_ID', 'YOUR_API_KEY')
 ```
 
 `new_client()` accepts a string, either **preprod**, **prod**, or a complete base URL. To register for a testing
@@ -108,7 +108,7 @@ save manifests by uploading new .json and/or .zip files require a file path.
 from emanifest import new_client
 
 rcrainfo = new_client('preprod')
-rcrainfo.auth('YOUR_API_ID', 'YOUR_API_KEY')
+rcrainfo.authenticate('YOUR_API_ID', 'YOUR_API_KEY')
 
 rcrainfo.get_site_details('VATEST000001')
 ```
@@ -119,7 +119,7 @@ Once you've confirmed this is the correct site, you might search for manifests i
 from emanifest import new_client
 
 rcrainfo = new_client('preprod')
-rcrainfo.auth('YOUR_API_ID', 'YOUR_API_KEY')
+rcrainfo.authenticate('YOUR_API_ID', 'YOUR_API_KEY')
 
 rcrainfo.search_mtn(siteId='VATEST000001', status='InTransit')
 ```
@@ -133,7 +133,7 @@ and optionally any attachments (.zip):
 from emanifest import new_client
 
 rcrainfo = new_client('preprod')
-rcrainfo.auth('YOUR_API_ID', 'YOUR_API_KEY')
+rcrainfo.authenticate('YOUR_API_ID', 'YOUR_API_KEY')
 
 rcrainfo.correct('manifest_file_name.json', 'optional_attachments.zip')
 ```

--- a/emanifest-py/requirements.txt
+++ b/emanifest-py/requirements.txt
@@ -1,9 +1,9 @@
 certifi==2022.12.7
 charset-normalizer==2.1.1
-emanifest @ file:///home/dg/Projects/e-Manifest/emanifest-py
+emanifest@ file:///home/dg/Projects/e-Manifest/emanifest-py
 idna==3.4
-packaging==22.0
+packaging==23.0
 pep517==0.13.0
-requests==2.28.1
+requests==2.28.2
 requests-toolbelt==0.10.1
-urllib3==1.26.13
+urllib3==1.26.14

--- a/emanifest-py/src/emanifest/client.py
+++ b/emanifest-py/src/emanifest/client.py
@@ -9,13 +9,13 @@ import os
 import zipfile
 from datetime import datetime, timedelta
 
-from requests import Response, Session, Request
+import requests
 from requests_toolbelt.multipart import decoder, encoder
 
 
 class RcrainfoResponse:
 
-    def __init__(self, response: Response):
+    def __init__(self, response: requests.Response):
         self.response = response
         self.zip = None
         self._multipart_json = None
@@ -53,10 +53,6 @@ class RcrainfoResponse:
 
 # noinspection PyIncorrectDocstring
 class RcrainfoClient:
-    # see datetime docs https://docs.python.org/3.7/library/datetime.html#strftime-strptime-behavior
-    __expiration_fmt = '%Y-%m-%dT%H:%M:%S.%f%z'
-    __default_header = {'Accept': 'application/json'}
-
     def __init__(self, base_url: str, *, api_id=None, api_key=None, timeout=10) -> None:
         self.base_url = _parse_url(base_url)
         self.__api_key = api_key
@@ -64,7 +60,6 @@ class RcrainfoClient:
         self.timeout = timeout
         self.token = None
         self._token_expiration = None
-        self.__session = Session()
 
     @property
     def token_expiration(self) -> datetime:
@@ -87,79 +82,53 @@ class RcrainfoClient:
         except TypeError:
             return False
 
-    @property
-    def expiration_format(self) -> str:
-        return self.__expiration_fmt
-
     def __str__(self) -> str:
         return f'RcrainfoClient: base URL {self.base_url}'
 
     def __repr__(self) -> str:
         return self.__str__()
 
-    def __bool__(self) -> bool:
-        """Return true if successfully authenticated"""
-        return self.authenticated
+    def __rcra_get(self, endpoint) -> RcrainfoResponse:
+        return RcrainfoResponse(requests.get(endpoint, timeout=self.timeout,
+                                             headers={'Accept': 'application/json',
+                                                      'Authorization': f'Bearer {self.token}'}))
 
-    def __rcra_request(self, method, endpoint, *, headers=None, multipart=None, stream=False, **kwargs
-                       ) -> RcrainfoResponse:
-        req_headers = {'Authorization': f'Bearer {self.token}'}
-        if headers is None:
-            req_headers.update(self.__default_header)
-        else:
-            req_headers = {**req_headers, **headers}
+    def __rcra_post(self, endpoint, **kwargs) -> RcrainfoResponse:
+        return RcrainfoResponse(requests.post(endpoint, timeout=self.timeout,
+                                              headers={'Content-Type': 'text/plain', 'Accept': 'application/json',
+                                                       'Authorization': f'Bearer {self.token}'},
+                                              data=json.dumps(dict(**kwargs))))
 
-        if method in ('POST', 'PUT', 'PATCH'):
-            if multipart is not None:
-                data = multipart
-            else:
-                data = json.dumps(dict(**kwargs))
-        else:
-            data = None
+    def __rcra_delete(self, endpoint) -> RcrainfoResponse:
+        return RcrainfoResponse(requests.delete(endpoint, timeout=self.timeout,
+                                                headers={'Accept': 'application/json',
+                                                         'Authorization': f'Bearer {self.token}'}))
 
-        req = self.__session.prepare_request(Request(method, url=endpoint, headers=req_headers, data=data))
-        return RcrainfoResponse(self.__session.send(req, timeout=self.timeout, stream=stream))
+    def __rcra_put(self, endpoint, m) -> RcrainfoResponse:
+        return RcrainfoResponse(requests.put(endpoint, timeout=self.timeout,
+                                             headers={'Content-Type': m.content_type, 'Accept': 'application/json',
+                                                      'Authorization': f'Bearer {self.token}'}, data=m))
 
     def __get_token(self):
         self.__api_id = self.retrieve_id()
         self.__api_key = self.retrieve_key()
         auth_url = f'{self.base_url}api/v1/auth/{self.__api_id}/{self.__api_key}'
-        resp = self.__session.get(auth_url, timeout=self.timeout)
+        resp = requests.get(auth_url, timeout=self.timeout)
         if resp.ok:
             self.token = resp.json()['token']
-            self._token_expiration = datetime.strptime(resp.json()['expiration'], self.__expiration_fmt)
+            # see datetime docs https://docs.python.org/3.7/library/datetime.html#strftime-strptime-behavior
+            expire_format = '%Y-%m-%dT%H:%M:%S.%f%z'
+            self._token_expiration = datetime.strptime(resp.json()['expiration'], expire_format)
 
-    # The following methods are exposed so users can hook into our client and customize its behavior
     def retrieve_id(self, api_id=None) -> str:
-        """
-        Getter method used internally to retrieve the desired RCRAInfo API ID. Can be overridden
-        to automatically support retrieving an API ID from an external location.
-        Args:
-            api_id:
-
-        Returns:
-            string of the user's RCRAInfo API ID
-        """
         if api_id:
             return api_id
         elif self.__api_id:
             return self.__api_id
         elif self.__api_id is None and api_id is None:
-            #  pass an empty string so, if user's fail to provide a string, it will not try to use None as
-            #  the API credential in the URL
             return ''
 
     def retrieve_key(self, api_key=None) -> str:
-        """
-        Getter method used internally to retrieve the desired RCRAInfo API key. Can be overridden
-        to automatically support retrieving an API Key from an external location.
-
-        Args:
-            api_key:
-
-        Returns:
-            string of the user's RCRAInfo API Key
-        """
         if api_key:
             return api_key
         elif self.__api_key:
@@ -167,7 +136,7 @@ class RcrainfoClient:
         elif self.__api_key is None and api_key is None:
             return ''
 
-    # Below this line are the high level methods to request RCRAInfo/e-Manifest
+    # Below this line starts the classes methods to interact with  RCRAInfo/e-Manifest
     def auth(self, api_id=None, api_key=None) -> None:
         """
         Authenticate user's RCRAInfo API ID and Key to generate token for use by other functions
@@ -181,10 +150,12 @@ class RcrainfoClient:
         """
         # if api credentials are passed, set the client's attributes
         if api_id is not None:
-            self.__api_id = str(api_id)
+            self.__api_id = api_id
         if api_key is not None:
-            self.__api_key = str(api_key)
-        self.__get_token()
+            self.__api_key = api_key
+
+        if None not in (self.__api_key, self.__api_id):
+            self.__get_token()
 
     def get_site_details(self, epa_id) -> RcrainfoResponse:
         """
@@ -197,7 +168,7 @@ class RcrainfoClient:
             dict: object with EPA ID site details
         """
         endpoint = f'{self.base_url}/api/v1/site-details/{epa_id}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_hazard_classes(self) -> RcrainfoResponse:
         """
@@ -207,7 +178,7 @@ class RcrainfoClient:
             dict: object with DOT hazard classes
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/hazard-classes'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_packing_groups(self) -> RcrainfoResponse:
         """
@@ -217,7 +188,7 @@ class RcrainfoClient:
             dict: object with DOT packing groups
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/packing-groups'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_haz_class_sn_id(self, ship_name, id_num) -> RcrainfoResponse:
         """
@@ -232,7 +203,7 @@ class RcrainfoClient:
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/hazard-class-by-shipping-name-id-number/' \
                    f'{ship_name}/{id_num}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_pack_groups_sn_id(self, ship_name, id_num) -> RcrainfoResponse:
         """
@@ -247,7 +218,7 @@ class RcrainfoClient:
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/packing-groups-by-shipping-name-id-number/' \
                    f'{ship_name}/{id_num}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_id_by_ship_name(self, ship_name) -> RcrainfoResponse:
         """
@@ -260,7 +231,7 @@ class RcrainfoClient:
             dict: object with DOT ID number
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/id-numbers-by-shipping-name/{ship_name}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_ship_name_by_id(self, id_num) -> RcrainfoResponse:
         """
@@ -273,7 +244,7 @@ class RcrainfoClient:
             dict: object with DOT Proper Shipping name 
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/proper-shipping-names-by-id-number/{id_num}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_mtn_suffix(self) -> RcrainfoResponse:
         """
@@ -283,7 +254,7 @@ class RcrainfoClient:
             dict: object with allowable MTN suffixes
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/printed-tracking-number-suffixes'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_mtn_suffix_all(self) -> RcrainfoResponse:
         """
@@ -293,7 +264,7 @@ class RcrainfoClient:
             dict: object with all allowable MTN suffixes
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/printed-tracking-number-suffixes-ALL'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_container_types(self) -> RcrainfoResponse:
         """
@@ -303,7 +274,7 @@ class RcrainfoClient:
             dict: object with container types
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/container-types'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_quantity_uom(self) -> RcrainfoResponse:
         """
@@ -313,7 +284,7 @@ class RcrainfoClient:
             dict: object with quantity UOM
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/quantity-uom'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_load_types(self) -> RcrainfoResponse:
         """
@@ -323,7 +294,7 @@ class RcrainfoClient:
             dict: object with load types
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/load-types'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_shipping_names(self) -> RcrainfoResponse:
         """
@@ -333,7 +304,7 @@ class RcrainfoClient:
             dict: object with DOT Proper Shipping names
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/proper-shipping-names'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_id_nums(self) -> RcrainfoResponse:
         """
@@ -343,7 +314,7 @@ class RcrainfoClient:
             dict: object with DOT Shipping ID numbers
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/lookup/id-numbers'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_density_uom(self) -> RcrainfoResponse:
         """
@@ -353,7 +324,7 @@ class RcrainfoClient:
             dict: object with density UOM
         """
         endpoint = f'{self.base_url}/api/v1/lookup/density-uom'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_form_codes(self) -> RcrainfoResponse:
         """
@@ -363,7 +334,7 @@ class RcrainfoClient:
             dict: object with form codes
         """
         endpoint = f'{self.base_url}/api/v1/lookup/form-codes'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_source_codes(self) -> RcrainfoResponse:
         """
@@ -373,7 +344,7 @@ class RcrainfoClient:
             dict: object with source codes
         """
         endpoint = f'{self.base_url}/api/v1/lookup/source-codes'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_state_waste_codes(self, state_code) -> RcrainfoResponse:
         """
@@ -383,7 +354,7 @@ class RcrainfoClient:
             dict: object with state waste codes
         """
         endpoint = f'{self.base_url}/api/v1/lookup/state-waste-codes/{state_code}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_fed_waste_codes(self) -> RcrainfoResponse:
         """
@@ -393,7 +364,7 @@ class RcrainfoClient:
             dict: object with federal waste codes
         """
         endpoint = f'{self.base_url}/api/v1/lookup/federal-waste-codes'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_man_method_codes(self) -> RcrainfoResponse:
         """
@@ -403,7 +374,7 @@ class RcrainfoClient:
             dict: object with management method codes
         """
         endpoint = f'{self.base_url}/api/v1/lookup/management-method-codes'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_waste_min_codes(self) -> RcrainfoResponse:
         """
@@ -413,7 +384,7 @@ class RcrainfoClient:
             dict: object with waste minimization codes
         """
         endpoint = f'{self.base_url}/api/v1/lookup/waste-minimization-codes'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_ports_of_entry(self) -> RcrainfoResponse:
         """
@@ -423,7 +394,7 @@ class RcrainfoClient:
             dict: object with ports of entry
         """
         endpoint = f'{self.base_url}/api/v1/lookup/ports-of-entry'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def check_site_exists(self, site_id) -> RcrainfoResponse:
         """
@@ -436,13 +407,13 @@ class RcrainfoClient:
             result (boolean): true/false confirmation if site exists
         """
         endpoint = f'{self.base_url}/api/v1/site-exists/{site_id}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def site_search(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve sites based on some or all of the provided criteria
         
-        Keyword Args:
+        Args:
             epaSiteId (str): EPA site ID
             name (str): Site name (e.g. The White House)
             streetNumber (str): Street number (e.g. 1600)
@@ -457,14 +428,14 @@ class RcrainfoClient:
             dict: object containing list of sites matching criteria and details about each site
         """
         endpoint = f'{self.base_url}/api/v1/site-search'
-        return self.__rcra_request('POST', endpoint, **kwargs)
+        return self.__rcra_post(endpoint, **kwargs)
 
     def user_search(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve users based on some or all of the provided criteria. Only users of sites accessible
         to the API keyholder will be visible
         
-        Keyword Args:
+        Args:
             userId (str) : A RCRAInfo username
             siteIds (array of strings) : One or more EPA site IDs
             pageNumber (number): must be greater than 0
@@ -473,13 +444,13 @@ class RcrainfoClient:
             dict: object containing list of users matching criteria and details about each user
         """
         endpoint = f'{self.base_url}/api/v1/user/user-search'
-        return self.__rcra_request('POST', endpoint, **kwargs)
+        return self.__rcra_post(endpoint, **kwargs)
 
     def get_billing_history(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve billing history for a given billing account ID
         
-        Keyword Args:
+        Args:
             billing_account (str): EPA Site ID
             start_month_year (date): First bill to be included (MM/YYYY format)
             end_month_year (date): Final bill to be included (MM/YYYY format)
@@ -488,13 +459,13 @@ class RcrainfoClient:
             dict: object containing billing history for the specified site and period
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/billing/bill-history'
-        return self.__rcra_request('POST', endpoint, **kwargs)
+        return self.__rcra_post(endpoint, **kwargs)
 
     def get_bill(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve bill information for a given bill ID and account ID
         
-        Keyword Args:
+        Args:
             billId (str): Bill ID
             billingAccount (str): EPA Site ID
             monthYear (date): Billing month (as MM/YYYY). Optional if billId is provided
@@ -503,13 +474,13 @@ class RcrainfoClient:
             dict: object containing bill information for the specified ID and account
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/billing/bill'
-        return self.__rcra_request('POST', endpoint, **kwargs)
+        return self.__rcra_post(endpoint, **kwargs)
 
     def search_bill(self, **kwargs) -> RcrainfoResponse:
         """
         Search and retrieve bills using all or some of the provided criteria
         
-        Keyword Args:
+        Args:
             billingAccount (str): EPA Site ID
             billStatus (str): Active, Paid, Unpaid, ReadyForPayment, Credit, InProgress, SendToCollections, ZeroBalance.
             startDate(date): Beginning of the billing period (yyyy-MM-dd'T'HH:mm:ssZ or yyyy-MM-dd'T'HH:mm:ss.SSSZ)
@@ -521,7 +492,7 @@ class RcrainfoClient:
             dict: object with bills matching criteria
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/billing/bill-search'
-        return self.__rcra_request('POST', endpoint, **kwargs)
+        return self.__rcra_post(endpoint, **kwargs)
 
     def get_attachments(self, mtn) -> RcrainfoResponse:
         """
@@ -535,8 +506,10 @@ class RcrainfoClient:
             attachments: PDF and HTML files containing additional manifest information (such as scans
             or electronic copies) for the given MTN
         """
-        endpoint = f'{self.base_url}/api/v1/emanifest/manifest/{mtn}/attachments'
-        resp = self.__rcra_request('GET', endpoint, headers={'Accept': 'multipart/mixed'}, stream=True)
+        resp = RcrainfoResponse(requests.get(f'{self.base_url}/api/v1/emanifest/manifest/{mtn}/attachments',
+                                             headers={'Accept': 'multipart/mixed',
+                                                      'Authorization': f'Bearer {self.token}'},
+                                             stream=True))
         if resp.response:
             resp.decode()
         return resp
@@ -545,7 +518,7 @@ class RcrainfoClient:
         """
         Retrieve manifest tracking numbers based on all or some of provided search criteria
         
-        Keyword Args:
+        Args:
             stateCode (str): Two-letter US postal state code
             siteId (str): EPA Site ID
             status (str): Pending, Scheduled, InTransit, Received, ReadyForSignature, Signed, SignedComplete,
@@ -559,7 +532,7 @@ class RcrainfoClient:
             dict: object containing manifest tracking numbers matching criteria
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/search'
-        return self.__rcra_request('POST', endpoint, **kwargs)
+        return self.__rcra_post(endpoint, **kwargs)
 
     def get_correction_details(self, mtn) -> RcrainfoResponse:
         """
@@ -572,13 +545,13 @@ class RcrainfoClient:
             dict: object containing correction details for given MTN
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest/correction-details/{mtn}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_correction_version(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve details of manifest correction version based on all or some of the provided search criteria
 
-        Keyword Args:
+        Args:
             manifestTrackingNumber (str): Manifest tracking number. Required
             status (str): Manifest status (Signed, Corrected, UnderCorrection). Case-sensitive
             ppcStatus (str): EPA Paper Processing Center Status (PendingDataEntry, DataQaCompleted). Case-sensitive
@@ -588,7 +561,7 @@ class RcrainfoClient:
             dict: object containing correction details
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest/correction-version'
-        return self.__rcra_request('POST', endpoint, **kwargs)
+        return self.__rcra_post(endpoint, **kwargs)
 
     def get_mtn_by_site(self, site_id) -> RcrainfoResponse:
         """
@@ -601,7 +574,7 @@ class RcrainfoClient:
             dict: object containing manifest tracking numbers for this site
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest-tracking-numbers/{site_id}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_man_by_mtn(self, mtn) -> RcrainfoResponse:
         """
@@ -614,7 +587,7 @@ class RcrainfoClient:
             dict: object containing e-Manifest details
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest/{mtn}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_sites(self, state_code, site_type) -> RcrainfoResponse:
         """
@@ -628,7 +601,7 @@ class RcrainfoClient:
             dict: object containing site ID numbers
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/site-ids/{state_code}/{site_type}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def correct(self, manifest_json, zip_file=None) -> RcrainfoResponse:
         """
@@ -641,9 +614,9 @@ class RcrainfoClient:
         Returns:
             dict: message of success or failure
         """
-        multipart = _encode_manifest(manifest_json, zip_file)
+        m = _encode_manifest(manifest_json, zip_file)
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest/correct'
-        return self.__rcra_request('PUT', endpoint, multipart=multipart)
+        return self.__rcra_put(endpoint, m)
 
     def revert(self, mtn) -> RcrainfoResponse:
         """
@@ -656,18 +629,18 @@ class RcrainfoClient:
             dict: object containing confirmation of correction
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest/revert/{mtn}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_correction_attachments(self, **kwargs) -> RcrainfoResponse:
-        r"""
+        """
         Retrieve attachments of corrected manifests based all or some of the provided search criteria
 
-        Keyword Args:
+        Args:
             manifestTrackingNumber (str): Manifest tracking number. Required
             status (str): Manifest status (Signed, Corrected, UnderCorrection). Case-sensitive
             ppcStatus (str): EPA Paper Processing Center Status (PendingDataEntry, DataQaCompleted). Case-sensitive
             versionNumber (str): Manifest version number
-
+            
         Returns:
             json: Downloaded file containing e-Manifest details for given MTN
             attachments: PDF and HTML files containing additional
@@ -675,8 +648,11 @@ class RcrainfoClient:
             electronic copies) for the given MTN
             print: message of success or failure
         """
-        endpoint = f'{self.base_url}/api/v1/emanifest/manifest/correction-version/attachments'
-        resp = self.__rcra_request('POST', endpoint, **kwargs)
+        resp = RcrainfoResponse(
+            requests.post(f'{self.base_url}/api/v1/emanifest/manifest/correction-version/attachments',
+                          headers={'Content-Type': 'text/plain', 'Accept': 'application/json',
+                                   'Authorization': f'Bearer {self.token}'},
+                          data=json.dumps(dict(**kwargs))))
         if resp.response:
             resp.decode()
         return resp
@@ -692,7 +668,7 @@ class RcrainfoClient:
             dict: object containing MTN details and confirmation if site exists
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest/mtn-exists/{mtn}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def update(self, manifest_json, zip_file=None) -> RcrainfoResponse:
         """
@@ -705,10 +681,10 @@ class RcrainfoClient:
         Returns:
             dict: message of success or failure
         """
-        multipart = _encode_manifest(manifest_json, zip_file)
+        m = _encode_manifest(manifest_json, zip_file)
 
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest/update'
-        return self.__rcra_request('PUT', endpoint, multipart=multipart)
+        return self.__rcra_put(endpoint, m)
 
     def delete(self, mtn) -> RcrainfoResponse:
         """
@@ -721,7 +697,7 @@ class RcrainfoClient:
             dict: message of success or failure
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest/delete/{mtn}'
-        return self.__rcra_request('DELETE', endpoint)
+        return self.__rcra_delete(endpoint)
 
     def save(self, manifest_json, zip_file=None) -> RcrainfoResponse:
         """
@@ -734,16 +710,18 @@ class RcrainfoClient:
         Returns:
             dict: message of success or failure
         """
-        multipart = _encode_manifest(manifest_json, zip_file)
-        endpoint = f'{self.base_url}/api/v1/emanifest/manifest/save'
-        return self.__rcra_request('POST', endpoint, headers={'Content-Type': multipart.content_type, 'Accept':
-            'application/json'}, multipart=multipart)
+        m = _encode_manifest(manifest_json, zip_file)
+        resp = RcrainfoResponse(requests.post(f'{self.base_url}/api/v1/emanifest/manifest/save',
+                                              headers={'Content-Type': m.content_type, 'Accept': 'application/json',
+                                                       'Authorization': f'Bearer {self.token}'},
+                                              data=m))
+        return resp
 
     def generate_ui_link(self, **kwargs) -> RcrainfoResponse:
         """
         Generate link to the user interface (UI) of the RCRAInfo e-Manifest module
         
-        Keyword Args:
+        Args:
             page (str): Dashboard, BulkSign, BulkQuickSign, Edit, View, Sign. Case-sensitive
             epaSiteId (Str): EPA Site ID
             manifestTrackingNumber (str): Manifest tracking number (optional)
@@ -753,7 +731,7 @@ class RcrainfoClient:
             dict: object containing link to UI
         """
         endpoint = f'{self.base_url}/api/v1/links/emanifest'
-        return self.__rcra_request('POST', endpoint, **kwargs)
+        return self.__rcra_post(endpoint, **kwargs)
 
     def cme_lookup(self, activity_location, agency_code, nrr_flag=True) -> RcrainfoResponse:
         """
@@ -775,7 +753,7 @@ class RcrainfoClient:
         """
         endpoint = f'{self.base_url}/api/v1/state/cme/evaluation/lookups/{activity_location}/{agency_code}/' \
                    f'{str(nrr_flag)}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def cme_indicators(self):
         """
@@ -785,7 +763,7 @@ class RcrainfoClient:
             dict: object containing all evaluation indicators
         """
         endpoint = f'{self.base_url}/api/v1/state/cme/evaluation/evaluation-indicators'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def cme_types(self) -> RcrainfoResponse:
         """
@@ -795,7 +773,7 @@ class RcrainfoClient:
             dict: object containing all evaluation types
         """
         endpoint = f'{self.base_url}/api/v1/state/cme/evaluation/evaluation-types'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_attachments_reg(self, mtn) -> RcrainfoResponse:
         """
@@ -810,8 +788,10 @@ class RcrainfoClient:
             electronic copies) for the given MTN
               message of success or failure
         """
-        endpoint = f'{self.base_url}/api/v1/state/emanifest/manifest/{mtn}/attachments'
-        resp = self.__rcra_request('GET', endpoint, headers={'Accept': 'multipart/mixed'}, stream=True)
+        resp = RcrainfoResponse(requests.get(f'{self.base_url}/api/v1/state/emanifest/manifest/{mtn}/attachments',
+                                             headers={'Accept': 'multipart/mixed',
+                                                      'Authorization': f'Bearer {self.token}'},
+                                             stream=True))
         if resp.response:
             resp.decode()
         return resp
@@ -820,7 +800,7 @@ class RcrainfoClient:
         """
         Retrieve manifest tracking numbers based on all or some of provided search criteria
         
-        Keyword Args:
+        Args:
             stateCode (str): Two-letter US postal state code
             siteId (str): EPA Site ID
             status (str): Pending, Scheduled, InTransit, Received, ReadyForSignature, Signed, SignedComplete,
@@ -834,7 +814,7 @@ class RcrainfoClient:
             dict: object containing manifest tracking numbers matching criteria
         """
         endpoint = f'{self.base_url}/api/v1/state/emanifest/search'
-        return self.__rcra_request('POST', endpoint, **kwargs)
+        return self.__rcra_post(endpoint, **kwargs)
 
     def get_correction_details_reg(self, mtn) -> RcrainfoResponse:
         """
@@ -847,13 +827,13 @@ class RcrainfoClient:
             dict: object containing correction details for given MTN
         """
         endpoint = f'{self.base_url}/api/v1/state/emanifest/manifest/correction-details/{mtn}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_correction_version_reg(self, **kwargs) -> RcrainfoResponse:
         """
         Retrieve details of manifest correction version based on all or some of the provided search criteria
 
-        Keyword Args:
+        Args:
             manifestTrackingNumber (str): Manifest tracking number. Required
             status (str): Manifest status (Signed, Corrected, UnderCorrection). Case-sensitive
             ppcStatus (str): EPA Paper Processing Center Status (PendingDataEntry, DataQaCompleted). Case-sensitive
@@ -863,7 +843,7 @@ class RcrainfoClient:
             dict: object containing correction details
         """
         endpoint = f'{self.base_url}/api/v1/state/emanifest/manifest/correction-version'
-        return self.__rcra_request('POST', endpoint, **kwargs)
+        return self.__rcra_post(endpoint, **kwargs)
 
     def get_mtn_by_site_reg(self, site_id) -> RcrainfoResponse:
         """
@@ -876,7 +856,7 @@ class RcrainfoClient:
             dict: object containing manifest tracking numbers for this site
         """
         endpoint = f'{self.base_url}/api/v1/state/emanifest/manifest-tracking-numbers/{site_id}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_man_by_mtn_reg(self, mtn) -> RcrainfoResponse:
         """
@@ -889,7 +869,7 @@ class RcrainfoClient:
             dict: object containing e-Manifest details
         """
         endpoint = f'{self.base_url}/api/v1/state/emanifest/manifest/{mtn}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_sites_reg(self, state_code, site_type) -> RcrainfoResponse:
         """
@@ -903,7 +883,7 @@ class RcrainfoClient:
             dict: object containing site ID numbers
         """
         endpoint = f'{self.base_url}/api/v1/state/emanifest/site-ids/{state_code}/{site_type}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
     def get_handler_reg(self, handler_id, details=False) -> RcrainfoResponse:
         """
@@ -917,7 +897,7 @@ class RcrainfoClient:
             dict: object containing handler source records (and optional details)
         """
         endpoint = f'/api/v1/state/handler/sources/{handler_id}/{str(details)}'
-        return self.__rcra_request('GET', endpoint)
+        return self.__rcra_get(endpoint)
 
 
 def new_client(base_url) -> RcrainfoClient:

--- a/emanifest-py/src/emanifest/client.py
+++ b/emanifest-py/src/emanifest/client.py
@@ -442,7 +442,7 @@ class RcrainfoClient:
         """
         Retrieve sites based on some or all of the provided criteria
         
-        Args:
+        Keyword Args:
             epaSiteId (str): EPA site ID
             name (str): Site name (e.g. The White House)
             streetNumber (str): Street number (e.g. 1600)
@@ -464,7 +464,7 @@ class RcrainfoClient:
         Retrieve users based on some or all of the provided criteria. Only users of sites accessible
         to the API keyholder will be visible
         
-        Args:
+        Keyword Args:
             userId (str) : A RCRAInfo username
             siteIds (array of strings) : One or more EPA site IDs
             pageNumber (number): must be greater than 0
@@ -479,7 +479,7 @@ class RcrainfoClient:
         """
         Retrieve billing history for a given billing account ID
         
-        Args:
+        Keyword Args:
             billing_account (str): EPA Site ID
             start_month_year (date): First bill to be included (MM/YYYY format)
             end_month_year (date): Final bill to be included (MM/YYYY format)
@@ -494,7 +494,7 @@ class RcrainfoClient:
         """
         Retrieve bill information for a given bill ID and account ID
         
-        Args:
+        Keyword Args:
             billId (str): Bill ID
             billingAccount (str): EPA Site ID
             monthYear (date): Billing month (as MM/YYYY). Optional if billId is provided
@@ -509,7 +509,7 @@ class RcrainfoClient:
         """
         Search and retrieve bills using all or some of the provided criteria
         
-        Args:
+        Keyword Args:
             billingAccount (str): EPA Site ID
             billStatus (str): Active, Paid, Unpaid, ReadyForPayment, Credit, InProgress, SendToCollections, ZeroBalance.
             startDate(date): Beginning of the billing period (yyyy-MM-dd'T'HH:mm:ssZ or yyyy-MM-dd'T'HH:mm:ss.SSSZ)
@@ -545,7 +545,7 @@ class RcrainfoClient:
         """
         Retrieve manifest tracking numbers based on all or some of provided search criteria
         
-        Args:
+        Keyword Args:
             stateCode (str): Two-letter US postal state code
             siteId (str): EPA Site ID
             status (str): Pending, Scheduled, InTransit, Received, ReadyForSignature, Signed, SignedComplete,
@@ -578,7 +578,7 @@ class RcrainfoClient:
         """
         Retrieve details of manifest correction version based on all or some of the provided search criteria
 
-        Args:
+        Keyword Args:
             manifestTrackingNumber (str): Manifest tracking number. Required
             status (str): Manifest status (Signed, Corrected, UnderCorrection). Case-sensitive
             ppcStatus (str): EPA Paper Processing Center Status (PendingDataEntry, DataQaCompleted). Case-sensitive
@@ -743,7 +743,7 @@ class RcrainfoClient:
         """
         Generate link to the user interface (UI) of the RCRAInfo e-Manifest module
         
-        Args:
+        Keyword Args:
             page (str): Dashboard, BulkSign, BulkQuickSign, Edit, View, Sign. Case-sensitive
             epaSiteId (Str): EPA Site ID
             manifestTrackingNumber (str): Manifest tracking number (optional)
@@ -820,7 +820,7 @@ class RcrainfoClient:
         """
         Retrieve manifest tracking numbers based on all or some of provided search criteria
         
-        Args:
+        Keyword Args:
             stateCode (str): Two-letter US postal state code
             siteId (str): EPA Site ID
             status (str): Pending, Scheduled, InTransit, Received, ReadyForSignature, Signed, SignedComplete,
@@ -853,7 +853,7 @@ class RcrainfoClient:
         """
         Retrieve details of manifest correction version based on all or some of the provided search criteria
 
-        Args:
+        Keyword Args:
             manifestTrackingNumber (str): Manifest tracking number. Required
             status (str): Manifest status (Signed, Corrected, UnderCorrection). Case-sensitive
             ppcStatus (str): EPA Paper Processing Center Status (PendingDataEntry, DataQaCompleted). Case-sensitive

--- a/emanifest-py/src/example.py
+++ b/emanifest-py/src/example.py
@@ -24,7 +24,7 @@ def main():
     mtn = '100032524ELC'
 
     rcrainfo = new_client('preprod')
-    rcrainfo.auth(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
+    rcrainfo.authenticate(os.getenv('RCRAINFO_API_ID'), os.getenv('RCRAINFO_API_KEY'))
 
     dot_numbers = rcrainfo.get_man_method_codes()
     # The Response can be accessed by calling the request.Response.json() method, or the json attribute for ease
@@ -33,27 +33,27 @@ def main():
     print(dot_numbers.json)
 
     # Get Manifest json
-    manifest = rcrainfo.get_man_by_mtn(mtn)
+    manifest = rcrainfo.get_manifest(mtn)
     print(manifest.json)
     # uncommenting the below will save manifest to './manifest.json'
     # if manifest.ok:
     #     with open('manifest.json', 'wb') as file:
     #         file.write(manifest.response.content)
 
-    manifest_attachments = rcrainfo.get_attachments(mtn)
+    manifest_attachments = rcrainfo.get_manifest_attachments(mtn)
     print(manifest_attachments.ok)
     # uncommenting the below line will save a number of files to your working directory
     # if manifest_attachments.ok:
     #     manifest_attachments.zip.extractall()
 
     # update the paper manifest with the path to .json and .zip file
-    update_resp = rcrainfo.update('example_update.json', 'example_update.zip')
+    update_resp = rcrainfo.update_manifest('example_update.json', 'example_update.zip')
     print(update_resp.ok)
 
     # or pass json as a string
     with open('example_update.json') as f:
         data = f.read()  # data is a string containing the manifest json
-        update_resp = rcrainfo.update(data)
+        update_resp = rcrainfo.update_manifest(data)
         print(update_resp.ok)
 
 

--- a/emanifest-py/src/test_client.py
+++ b/emanifest-py/src/test_client.py
@@ -12,13 +12,11 @@ class TestEmanifestClient(unittest.TestCase):
     def setUp(self) -> None:
         api_id = os.getenv('RCRAINFO_API_ID')
         api_key = os.getenv('RCRAINFO_API_KEY')
-        print(api_key)
-        print(api_id)
         if not api_id:
             self.fail('API ID not found to test integration')
         elif not api_key:
             self.fail('API Key not found to test integration')
-        self.rcrainfo.auth(api_id, api_key)
+        self.rcrainfo.authenticate(api_id, api_key)
 
     def test_initial_zip_state(self):
         rcra_response = self.rcrainfo.get_site_details('VATESTGEN001')
@@ -30,14 +28,14 @@ class TestEmanifestClient(unittest.TestCase):
     # RcrainfoResponse test
     def test_extracted_response_json_matches(self):
         resp = self.rcrainfo.get_site_details('VATESTGEN001')
-        self.assertEqual(resp.response.json(), resp.json, "response.json() and json do not match")
+        self.assertEqual(resp.response.json(), resp.json(), "response.json() and json do not match")
 
     def test_decode_multipart_string(self):
-        manifest_response = self.rcrainfo.get_attachments("000012345GBF")
-        self.assertEqual(type(manifest_response.json), str)
+        manifest_response = self.rcrainfo.get_manifest_attachments("000012345GBF")
+        self.assertEqual(type(manifest_response.json()), str)
 
     def test_decode_multipart_zipfile(self):
-        manifest_response = self.rcrainfo.get_attachments("000012345GBF")
+        manifest_response = self.rcrainfo.get_manifest_attachments("000012345GBF")
         self.assertEqual(type(manifest_response.zip), zipfile.ZipFile)
 
     # Specific method related testing
@@ -48,17 +46,13 @@ class TestEmanifestClient(unittest.TestCase):
 
     def test_check_mtn_exits(self):
         mtn = "100032934ELC"
-        self.assertEqual(self.rcrainfo.check_mtn_exists(mtn).response.json()["manifestTrackingNumber"], mtn)
+        self.assertEqual(self.rcrainfo.check_mtn_exists(mtn).json()["manifestTrackingNumber"], mtn)
 
     def test_shipping_names(self):
         self.assertIn("Acetal", self.rcrainfo.get_shipping_names().response.json())
 
     def test_dot_numbers(self):
-        self.assertIn("UN1088", self.rcrainfo.get_id_nums().response.json())
-
-    def test_get_attachments(self):
-        manifest_response = self.rcrainfo.get_attachments("000012345GBF")
-        self.assertTrue(manifest_response.ok)
+        self.assertIn("UN1088", self.rcrainfo.get_id_numbers().response.json())
 
     def test_correction_get_attachments(self):
         manifest_response = self.rcrainfo.get_correction_attachments(manifestTrackingNumber="000012345GBF")
@@ -106,7 +100,7 @@ class BadClient(unittest.TestCase):
 
     # test of initial state
     def test_bad_auth(self):
-        self.bad_rcrainfo.auth(os.getenv('RCRAINFO_API_ID'), 'a_bad_api_key')
+        self.bad_rcrainfo.authenticate(os.getenv('RCRAINFO_API_ID'), 'a_bad_api_key')
         self.assertIsNone(self.bad_rcrainfo.token)
 
     def test_client_token_state(self):

--- a/emanifest-py/src/test_client.py
+++ b/emanifest-py/src/test_client.py
@@ -60,10 +60,6 @@ class TestEmanifestClient(unittest.TestCase):
         manifest_response = self.rcrainfo.get_attachments("000012345GBF")
         self.assertTrue(manifest_response.ok)
 
-    def test_correction_get_attachments(self):
-        manifest_response = self.rcrainfo.get_correction_attachments(manifestTrackingNumber="000012345GBF")
-        self.assertTrue(manifest_response.ok)
-
 
 class TestRcrainfoClientIsExtendable:
     class MyClass(emanifest.RcrainfoClient):

--- a/emanifest-py/src/test_client.py
+++ b/emanifest-py/src/test_client.py
@@ -60,6 +60,10 @@ class TestEmanifestClient(unittest.TestCase):
         manifest_response = self.rcrainfo.get_attachments("000012345GBF")
         self.assertTrue(manifest_response.ok)
 
+    def test_correction_get_attachments(self):
+        manifest_response = self.rcrainfo.get_correction_attachments(manifestTrackingNumber="000012345GBF")
+        self.assertTrue(manifest_response.ok)
+
 
 class TestRcrainfoClientIsExtendable:
     class MyClass(emanifest.RcrainfoClient):


### PR DESCRIPTION
## Major changes
This PR builds of #1523 and does two major things

1. The RcrainfoClient now subclasses the requests.Session Class. With that we get a fair amount of functionality for free (as they say) instead of initiating a Session object and storing it as `self.__session` field. 
    * We can now point to the [requests.Session](https://requests.readthedocs.io/en/latest/user/advanced/#session-objects) documentation, emanifest-py users can, if they wish take advantage of things like http lifecycle hooks. We can also build on that as well (such as putting the multipart decode functionality in a hook)
 
2. The RcrainfoClient class now auto authenticates.
    * api credentials can be passed in during object initialization like
  ```python 
rcrainfo = RcrainfoClient('preprod', api_id='foo', api_key='bar')
rcrainfo.get_manifest('123456789ELC')
```
will automatically make a request to the rcrainfo `/api/v1/auth/<api_id>/<api_key>` endpoint to retrieve and store a token before retrieving manifest 123456789ELC.

Users can still explictly authenticate their client with the `RcrainfoClient.authenticate()` method (I had to change `auth` to `authenticate` to avoid a naming conflict with the requests.Session class, I think it's for the better anyways).

## Minor fixes
I addition, this PR fixes a couple other things,
1. the `is_authenticated` property compares the token to an offset/timezone aware `datetime.datetime` object. 
2. I changed some of the request methods to follow a more consistent pattern of `<action>_<resource>` so instead of `save()` we have `save_manifest()`
3. Update the test suite
    * I went a head and cleaned up some of the redundant tests and it's now a pytest centric test suite instead of hybrid. 


## Potential future additions
1. Setters for `RcrainfoClient.__api_id` and `RcrainfoClient.__api_key`
    * I'm not sure we should include getters, I'm kind of the opinion that we shouldn't make it easy to retrieve the user's api credentials from RcrainfoClient. Not that people can't get pass the dunder field mangling now if they really wanted to, I'd just don't think we should encourage users to be able to do the following
```python
print(rcrainfo.api_key)
```
but I do think we should have a way for people to update the api credentials instead of having to init a new RcrainfoClient, like so
```python
rcrainfo.api_key = os.getenv('RCRAINFO_API_KEY')
```
2. The `new_client` convenience function is less of a convenience now. We either need to just get rid of it, of update it match `RcrainfoClient.__init__` method signature.
5. Update the docs
6. continue updating the test suite
