### PR TITLE
Add quicker sign functionality to the e-Manifest Python package

### DIFF
--- a/emanifest-py/pyproject.toml
+++ b/emanifest-py/pyproject.toml
@@ -5,6 +5,7 @@ description = "An API utility wrapper for accessing the e-Manifest hazardous was
 readme = "README.md"
 authors = [
     { name = "William Nicholas ", email = "nicholas.william@epa.gov" },
+    { name = "David Graham", email = "graham.david@epa.gov" },
 ]
 maintainers = [
     { name = "William Nicholas", email = "nicholas.william@epa.gov" },

--- a/emanifest-py/pyproject.toml
+++ b/emanifest-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "emanifest"
-version = "3.0.1"
+version = "3.0.2"
 description = "An API utility wrapper for accessing the e-Manifest hazardous waste tracking system maintainedby the US Environmental Protection Agency"
 readme = "README.md"
 authors = [

--- a/emanifest-py/src/emanifest/client.py
+++ b/emanifest-py/src/emanifest/client.py
@@ -967,8 +967,8 @@ def _parse_url(base_url: str) -> str:
     """emanifest-py internal helper function"""
     if "https" not in base_url:
         urls = {
-            "PROD": "https://rcrainfo.epa.gov/rcrainfoprod/rest/",
-            "PREPROD": "https://rcrainfopreprod.epa.gov/rcrainfo/rest/"
+            "PROD": "https://rcrainfo.epa.gov/rcrainfoprod/rest",
+            "PREPROD": "https://rcrainfopreprod.epa.gov/rcrainfo/rest"
         }
         if base_url.upper() in urls:
             return urls[base_url.upper()]

--- a/emanifest-py/src/emanifest/client.py
+++ b/emanifest-py/src/emanifest/client.py
@@ -841,6 +841,24 @@ class RcrainfoClient(Session):
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest/delete/{mtn}'
         return self.__rcra_request('DELETE', endpoint)
+    
+    def quicker_sign_manifest(self, reg: bool = False, **kwargs) -> RcrainfoResponse:
+        """
+        Quicker sign selected manifests
+        
+        Args:
+            manifestTrackingNumbers (array) : An array of manifest tracking numbers to sign
+            siteId (str) : The EPA ID for the site that signs
+            siteType (str) : The site on the manifest that is signing (Generator, Tsdf, Transporter, RejectionInfo_AlternateTsdf). Case-sensitive
+            printedSignatureName (str) : The name of the person who signed the manifest
+            printedSignatureDate (date) : The date the person signed the manifest
+            transporterOrder (int) : If the site is a transporter, the order of that transporter on the manifest
+            
+        Returns:
+            dict: message of success or failure
+        """
+        endpoint = f'{self.base_url}/api/v1/emanifest/manifest/quicker-sign'
+        return self.__rcra_request('POST', endpoint)
 
     def save_manifest(self, manifest_json: str, zip_file: bytes = None) -> RcrainfoResponse:
         """

--- a/emanifest-py/src/emanifest/client.py
+++ b/emanifest-py/src/emanifest/client.py
@@ -842,7 +842,7 @@ class RcrainfoClient(Session):
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest/delete/{mtn}'
         return self.__rcra_request('DELETE', endpoint)
     
-    def quicker_sign_manifest(self, reg: bool = False, **kwargs) -> RcrainfoResponse:
+    def sign_manifest(self, **kwargs) -> RcrainfoResponse:
         """
         Quicker sign selected manifests
         
@@ -858,7 +858,7 @@ class RcrainfoClient(Session):
             dict: message of success or failure
         """
         endpoint = f'{self.base_url}/api/v1/emanifest/manifest/quicker-sign'
-        return self.__rcra_request('POST', endpoint)
+        return self.__rcra_request('POST', endpoint, **kwargs)
 
     def save_manifest(self, manifest_json: str, zip_file: bytes = None) -> RcrainfoResponse:
         """

--- a/emanifest-py/src/tests/resources/quicker_sign.json
+++ b/emanifest-py/src/tests/resources/quicker_sign.json
@@ -1,0 +1,11 @@
+{
+  "siteId": "AK002",
+  "siteType": "Transporter",
+  "transporterOrder": 1,
+  "printedSignatureName": "AT",
+  "printedSignatureDate": "2021-10-27T03:19:25.443+0000",
+  "manifestTrackingNumbers": [
+    "200030073ELC",
+    "100030074ELC"
+  ]
+}


### PR DESCRIPTION
This PR adds the Quicker Sign functionality to the Python package. It also adds an example JSON file to the testing documentation.

This PR also addresses the duplicative "/" in the RcrainfoClient base_url to close #1535 