### PR TITLE
Unit Test Mock responses

### DIFF
--- a/.github/workflows/test_emanpy.yaml
+++ b/.github/workflows/test_emanpy.yaml
@@ -1,0 +1,36 @@
+name: Test e-Manifest Python Package
+
+on:
+  push:
+    paths:
+      - e-manifest-py/*
+
+jobs:
+  test:
+    name: Test on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: e-manifest-py
+    strategy:
+      matrix:
+        python-version: [ "3.10", "3.11" ]
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
+
+      - name: Test with pytest
+        run: |
+          pytest

--- a/emanifest-py/requirements_dev.txt
+++ b/emanifest-py/requirements_dev.txt
@@ -1,3 +1,4 @@
 pytest==7.3.1
 -r requirements.txt
 ruff==0.0.277
+responses==0.23.3

--- a/emanifest-py/src/emanifest/client.py
+++ b/emanifest-py/src/emanifest/client.py
@@ -128,7 +128,7 @@ class RcrainfoClient(Session):
         try:
             self.__token_expiration_utc = datetime.strptime(
                 expiration, self.__expiration_fmt
-            )
+            ).replace(tzinfo=timezone.utc)
         except ValueError:
             self.__token_expiration_utc = datetime.utcnow().replace(tzinfo=timezone.utc)
 

--- a/emanifest-py/src/emanifest/test_client.py
+++ b/emanifest-py/src/emanifest/test_client.py
@@ -1,5 +1,4 @@
 import os
-import zipfile
 
 import pytest
 import requests
@@ -34,59 +33,52 @@ class TestRcrainfoClient:
     rcrainfo = RcrainfoClient("preprod", api_id=api_id, api_key=api_key)
 
     def test_zip_attribute_is_none_when_attachment_not_returned(self, mock_response):
+        # Arrange
         mock_response.add(
+            # Add mock response for site-details endpoint
             responses.GET,
             f"{self.rcrainfo.base_url}v1/site-details/{TEST_GEN_ID}",
             json={
                 "epaSiteId": TEST_GEN_ID,
             },
         )
-        # manifest_response = self.rcrainfo.get_manifest_attachments(TEST_GEN_ID)
+        # Act
         rcra_response = self.rcrainfo.get_site(TEST_GEN_ID)
+        # Assert
         assert rcra_response.zip is None
 
     def test_token_when_is_authenticated(self, mock_response):
+        # Arrange
         client = RcrainfoClient("preprod")
+        # Act
         client.authenticate(api_id=MOCK_API_ID, api_key=MOCK_API_KEY)
+        # Assert
         assert isinstance(client.token, str) and client.is_authenticated
 
-    def test_token_when_not_authenticated(self):
+    def test_token_is_none_when_not_authenticated(self):
         new_rcrainfo = RcrainfoClient("preprod")
         assert new_rcrainfo.token is None and not new_rcrainfo.is_authenticated
 
-    # RcrainfoResponse test
-    def test_extracted_response_json_matches(self):
-        resp: RcrainfoResponse = self.rcrainfo.get_site(TEST_GEN_ID)
+    def test_extracted_response_json_matches(self, mock_response):
+        # Arrange
+        rcrainfo = new_client(
+            "preprod", api_id=self.api_id, api_key=self.api_key, auto_renew=True
+        )
+        mock_response.add(
+            # Add mock response for site-details endpoint
+            responses.GET,
+            f"{self.rcrainfo.base_url}v1/site-details/{TEST_GEN_ID}",
+            json={
+                "epaSiteId": TEST_GEN_ID,
+            },
+        )
+        # Act
+        resp: RcrainfoResponse = rcrainfo.get_site(TEST_GEN_ID)
+        # Assert
         assert resp.response.json() == resp.json()
 
-    def test_decode_multipart_string(self):
-        manifest_response = self.rcrainfo.get_manifest_attachments(TEST_GEN_MTN)
-        assert isinstance(manifest_response.json(), str)
 
-    def test_decode_multipart_zipfile(self):
-        manifest_response = self.rcrainfo.get_manifest_attachments(TEST_GEN_MTN)
-        assert isinstance(manifest_response.zip, zipfile.ZipFile)
-
-    # Specific method related testing
-    def test_get_site_details(self):
-        rcra_response = self.rcrainfo.get_site(TEST_GEN_ID)
-        site_details = rcra_response.response.json()
-        assert site_details["epaSiteId"] == TEST_GEN_ID
-
-    def test_check_mtn_exits(self):
-        mtn = "100032934ELC"
-        assert (
-                self.rcrainfo.check_mtn_exists(mtn).json()["manifestTrackingNumber"] == mtn
-        )
-
-    def test_correction_get_attachments(self):
-        response = self.rcrainfo.get_correction_attachments(
-            manifestTrackingNumber=TEST_GEN_MTN
-        )
-        assert response.ok is True
-
-
-class TestClientIsExtendable:
+class TestRcrainfoClientIsExtendable:
     class MyClass(RcrainfoClient):
         mock_api_id_from_external = "an_api_id_from_someplace_else"
         mock_api_key_from_external = "a_api_key_from_someplace_else"
@@ -127,28 +119,62 @@ class TestClientIsExtendable:
 
 
 class TestAutoAuthentication:
-    api_id = os.getenv("RCRAINFO_API_ID")
-    api_key = os.getenv("RCRAINFO_API_KEY")
+    api_id = MOCK_API_ID
+    api_key = MOCK_API_KEY
 
-    def test_automatically_authenticates(self):
+    @responses.activate
+    def test_not_automatically_authenticates_by_default(self):
         """
-        RcrainfoClient will automatically authenticate once a request is made,
-        (e.g., calling get_manifest(...) will do the equivalent of authenticate(...) first
+        RcrainfoClient does not automatically authenticate (via the auth endpoint) by default
         """
-        rcrainfo = RcrainfoClient("preprod", api_key=self.api_key, api_id=self.api_id)
+        # Arrange
+        rcrainfo = new_client("preprod", api_id=self.api_id, api_key=self.api_key)
+        responses.add(
+            # Add mock response for site-details endpoint
+            responses.GET,
+            f"{rcrainfo.base_url}v1/emanifest/manifest/{TEST_GEN_MTN}",
+            json={
+                "manifestTrackingNumber": TEST_GEN_MTN,
+            },
+        )
+        auth_response = responses.add(
+            responses.GET,
+            f"{RCRAINFO_PREPROD}v1/auth/{MOCK_API_ID}/{MOCK_API_KEY}",
+            json={
+                "token": "mock_token",
+                "expiration": "mock_expiration",
+            },
+        )
+        # Act
         _resp = rcrainfo.get_manifest(TEST_GEN_MTN)
-        assert rcrainfo.is_authenticated
+        # Assert
+        assert auth_response.call_count == 0
 
-    def test_does_not_authenticate_when_false(self):
-        """
-        emanifest(py) package will auto-authenticate (and re-authenticate) unless
-        the auto_renew argument is set to False
-        """
-        rcrainfo = RcrainfoClient(
-            "preprod", api_key=self.api_key, api_id=self.api_id, auto_renew=False
+    @responses.activate
+    def test_authenticates_when_auto_renew_set_to_true(self):
+        # Arrange
+        # create a new auto authenticating client
+        rcrainfo = new_client(
+            "preprod", api_id=self.api_id, api_key=self.api_key, auto_renew=True
+        )
+        responses.add(
+            # Add mock response for site-details endpoint
+            responses.GET,
+            f"{rcrainfo.base_url}v1/emanifest/manifest/{TEST_GEN_MTN}",
+            json={
+                "manifestTrackingNumber": TEST_GEN_MTN,
+            },
+        )
+        auth_response = responses.add(
+            responses.GET,
+            f"{RCRAINFO_PREPROD}v1/auth/{MOCK_API_ID}/{MOCK_API_KEY}",
+            json={
+                "token": "mock_token",
+                "expiration": "mock_expiration",
+            },
         )
         _resp = rcrainfo.get_manifest(TEST_GEN_MTN)
-        assert not rcrainfo.is_authenticated
+        assert auth_response.call_count > 0
 
     def test_non_present_credentials_does_not_auth(self):
         new_rcrainfo = RcrainfoClient("preprod")

--- a/emanifest-py/src/emanifest/test_client.py
+++ b/emanifest-py/src/emanifest/test_client.py
@@ -15,11 +15,15 @@ MOCK_API_KEY = "mock_api_key"
 
 @pytest.fixture
 def mock_response():
+    token_expiration = "2053-08-04T22:24:42.724+00:00"
     with responses.RequestsMock() as rsps:
         rsps.add(
             responses.GET,
             f"{RCRAINFO_PREPROD}v1/auth/{MOCK_API_ID}/{MOCK_API_KEY}",
-            json={"token": "mock_token", "expiration": "mock_expiration"},
+            json={
+                "token": "mock_token",
+                "expiration": token_expiration,
+            },
         )
         yield rsps
 
@@ -41,8 +45,10 @@ class TestRcrainfoClient:
         rcra_response = self.rcrainfo.get_site(TEST_GEN_ID)
         assert rcra_response.zip is None
 
-    def test_token_when_is_authenticated(self):
-        assert isinstance(self.rcrainfo.token, str) and self.rcrainfo.is_authenticated
+    def test_token_when_is_authenticated(self, mock_response):
+        client = RcrainfoClient("preprod")
+        client.authenticate(api_id=MOCK_API_ID, api_key=MOCK_API_KEY)
+        assert isinstance(client.token, str) and client.is_authenticated
 
     def test_token_when_not_authenticated(self):
         new_rcrainfo = RcrainfoClient("preprod")


### PR DESCRIPTION
# For the emanifest 4.0 release

This PR adds mock HTTP responses to our unit test so we can run our test without ever touching the rcrainfo services (something that we should have done a long time ago but hey, what chu gonna do). 

talk to you next week. 