### PR TITLE
Method input validations

### DIFF
--- a/emanifest-js/README.md
+++ b/emanifest-js/README.md
@@ -99,6 +99,7 @@ initiation.
 3. `siteType` must be one of the following: ['Generator', 'Tsdf', 'Transporter', 'Rejection_AlternateTsdf']
 4. `dateType` (a search parameter) must be one of the
    following: ['CertifiedDate', 'ReceivedDate', 'ShippedDate', 'UpdatedDate']
+5. `manifestTrackingNumber` must be a string of length 12
 
 Upon validation failure, the `RcraClient` will throw an error which can be caught and handled the same as an error
 received from the axios library.

--- a/emanifest-js/README.md
+++ b/emanifest-js/README.md
@@ -5,10 +5,11 @@
 ## Intro
 
 The [emanifest npm package](https://www.npmjs.com/package/emanifest) is an API client library.
-It simplifies the task of using the RCRAInfo/e-Manifest web services by abstracting the 
+It simplifies the task of using the RCRAInfo/e-Manifest web services by abstracting the
 authentication process, providing developer friendly API, and exporting TypeScript types.
-It's built on top of the [Axios](https://axios-http.com/) library, and can be used in both Node and browser 
-runtime environments (EPA has discussed making some public API available that do not need authentication in the near future).
+It's built on top of the [Axios](https://axios-http.com/) library, and can be used in both Node and browser
+runtime environments (EPA has discussed making some public API available that do not need authentication in the near
+future).
 
 For additional information about e-Manifest, check out the below links
 
@@ -22,20 +23,21 @@ For a python alternative see the [emanifest package on PyPI](https://pypi.org/pr
 
 ## Installation
 
-```bash 
-  $ npm install emanifest 
+```bash
+  $ npm install emanifest
   or
   $ yarn add emanifest
 ```
+
 ## Basic Usage
 
 The primary export of the `emanifest` package is the `newClient` function.
-A constructor that accepts a configuration object and returns a new `RcraClient` 
-instance. 
+A constructor that accepts a configuration object and returns a new `RcraClient`
+instance.
 
 ```typescript
 import { AxiosResponse } from 'axios';
-import { newClient, RCRAINFO_PREPROD, AuthResponse } from 'emanifest'
+import { newClient, RCRAINFO_PREPROD, AuthResponse } from 'emanifest';
 
 // The newClient accepts an instance of the RcraClientConfig which follows this interface
 // interface RcraClientConfig {
@@ -43,25 +45,25 @@ import { newClient, RCRAINFO_PREPROD, AuthResponse } from 'emanifest'
 // apiID?: string;
 // apiKey?: string;
 // authAuth?: Boolean; // default: false
+// validateInput?: Boolean; // default: false
 // }
 
-const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD, apiID: 'my_api_id', apiKey: 'my_api_key' })
-const authResponse: AxiosResponse<AuthResponse> = await rcrainfo.authenticate()
-console.log(authResponse.data)
-
+const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD, apiID: 'my_api_id', apiKey: 'my_api_key' });
+const authResponse: AxiosResponse<AuthResponse> = await rcrainfo.authenticate();
+console.log(authResponse.data);
 ```
 
-### Other Exports 
+### Other Exports
 
-The emanifest package also exports the `RCRAINFO_PREPROD` and `RCRAINFO_PROD` constants which can be used to set 
+The emanifest package also exports the `RCRAINFO_PREPROD` and `RCRAINFO_PROD` constants which can be used to set
 the `apiBaseURL` property of the `RcraClientConfig` object.
 
 ### Types
 
 The emanifest package exports a types/interfaces that can be used in statically typed projects.
-The types follow the OpenAPI schema definitions that can be found in the [USEPA/e-manifest schema directory](https://github.com/USEPA/e-manifest/tree/master/Services-Information/Schema)
+The types follow the OpenAPI schema definitions that can be found in
+the [USEPA/e-manifest schema directory](https://github.com/USEPA/e-manifest/tree/master/Services-Information/Schema)
 however, some names have been modified for clarity (for example `RcraCode` instead of simply `Code`).
-
 
 ## Auto-Authentication
 
@@ -69,24 +71,41 @@ The `emanifest` package can be explicitly configured to automatically authentica
 
 ```typescript
 import { AxiosResponse } from 'axios';
-import { newClient, RCRAINFO_PREPROD, AuthResponse, RcraClientClass, RcraCode } from 'emanifest'
+import { newClient, RCRAINFO_PREPROD, AuthResponse, RcraClientClass, RcraCode } from 'emanifest';
 
 const rcrainfo = newClient({
   apiBaseURL: RCRAINFO_PREPROD,
   apiID: 'my_api_id',
   apiKey: 'my_api_key',
-  autoAuth: true // Set the RcraClient to automatically authenticate as needed
-})
+  autoAuth: true, // Set the RcraClient to automatically authenticate as needed
+});
 
 // the authenticate method is NOT explicitly called
-const resp: AxtiosResponse<RcraCode> = await rcrainfo.getStateWasteCodes('VA')
+const resp: AxtiosResponse<RcraCode> = await rcrainfo.getStateWasteCodes('VA');
 
-console.log(resp.data) // [ { code: 'BCRUSH', description: 'Bulb or Lamp Crusher' } ]
+console.log(resp.data); // [ { code: 'BCRUSH', description: 'Bulb or Lamp Crusher' } ]
 
-console.log(rcrainfo.isAuthenticated()) // true
-
+console.log(rcrainfo.isAuthenticated()); // true
 ```
 
+## Input Validation
+
+The `emanifest` package can be explicitly configured to provide some simple input validation. This behavior is disabled
+by default. It must be explicitly enabled by setting the `validateInput` property of the `RcraClientConfig` on
+initiation.
+
+1. `siteID` must be a string of length 12
+2. `stateCode` must be a string of length 2
+3. `siteType` must be one of the following: ['Generator', 'Tsdf', 'Transporter', 'Rejection_AlternateTsdf']
+4. `dateType` (a search parameter) must be one of the
+   following: ['CertifiedDate', 'ReceivedDate', 'ShippedDate', 'UpdatedDate']
+
+Upon validation failure, the `RcraClient` will throw an error which can be caught and handled the same as an error
+received from the axios library.
+
+```typescript
+
+```
 
 ## Disclaimer
 

--- a/emanifest-js/README.md
+++ b/emanifest-js/README.md
@@ -44,7 +44,7 @@ import { newClient, RCRAINFO_PREPROD, AuthResponse } from 'emanifest';
 // apiBaseURL?: RcrainfoEnv; // default: RCRAINFO_PREPROD
 // apiID?: string;
 // apiKey?: string;
-// authAuth?: Boolean; // default: false
+// autoAuth?: Boolean; // default: false
 // validateInput?: Boolean; // default: false
 // }
 
@@ -60,7 +60,7 @@ the `apiBaseURL` property of the `RcraClientConfig` object.
 
 ### Types
 
-The emanifest package exports a types/interfaces that can be used in statically typed projects.
+The emanifest package exports types/interfaces that can be used in statically typed projects.
 The types follow the OpenAPI schema definitions that can be found in
 the [USEPA/e-manifest schema directory](https://github.com/USEPA/e-manifest/tree/master/Services-Information/Schema)
 however, some names have been modified for clarity (for example `RcraCode` instead of simply `Code`).
@@ -105,6 +105,16 @@ Upon validation failure, the `RcraClient` will throw an error which can be caugh
 received from the axios library.
 
 ```typescript
+import { newClient } from 'emanifest';
+
+const rcrainfo = newClient({ validateInput: true });
+
+try {
+  const resp = await rcrainfo.getSite('VA12345');
+} catch (err) {
+  console.log(err.message); // "siteID must be a string of length 12"
+}
+```
 
 ```
 
@@ -120,3 +130,4 @@ otherwise, does not constitute or imply their endorsement, recommendation
 or favoring by EPA. The EPA seal and logo shall not be used in any manner
 to imply endorsement of any commercial product or activity by EPA or
 the United States Government.
+```

--- a/emanifest-js/package.json
+++ b/emanifest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emanifest",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "API client library, written in TypeScript, for using the EPA e-Manifest/RCRAInfo web services.",
   "type": "module",
   "main": "./dist/emanifest-lib.umd.cjs",

--- a/emanifest-js/src/client.ts
+++ b/emanifest-js/src/client.ts
@@ -6,6 +6,8 @@ import {
   BillGetParameters,
   BillHistoryParameters,
   BillSearchParameters,
+  DateType,
+  dateTypeValues,
   ManifestCorrectionParameters,
   ManifestExistsResponse,
   ManifestSearchParameters,
@@ -366,6 +368,16 @@ class RcraClient {
    * Retrieve manifest tracking numbers based on provided search criteria in JSON format.
    */
   public searchManifest = async (parameters: ManifestSearchParameters): Promise<AxiosResponse<any>> => {
+    // Many of the search parameters are optional, we only want to validate them if they are provided.
+    if (parameters.dateType) {
+      this.validateDateType(parameters.dateType);
+    }
+    if (parameters.stateCode) {
+      this.validateStateCode(parameters.stateCode);
+    }
+    if (parameters.siteType) {
+      this.validateSiteType(parameters.siteType);
+    }
     return this.apiClient.post('v1/emanifest/manifest/search', parameters);
   };
 
@@ -429,7 +441,13 @@ class RcraClient {
 
   private validateSiteType = (siteType: SiteType): void => {
     if (!siteTypeValues.includes(siteType)) {
-      throw new Error('Site types must be ${siteTypeValues}');
+      throw new Error(`Site types must be ${siteTypeValues}`);
+    }
+  };
+
+  private validateDateType = (dateType: DateType): void => {
+    if (!dateTypeValues.includes(dateType)) {
+      throw new Error(`Site types must be ${dateTypeValues}`);
     }
   };
 }

--- a/emanifest-js/src/client.ts
+++ b/emanifest-js/src/client.ts
@@ -220,6 +220,7 @@ class RcraClient {
    * Get a site by its EPA ID.
    */
   public getSite = async (siteID: string): Promise<AxiosResponse> => {
+    this.validateSiteID(siteID);
     return this.apiClient.get(`v1/site-details/${siteID}`);
   };
 
@@ -227,6 +228,7 @@ class RcraClient {
    * Returns true if the site, by EPA ID, exists in RCRAInfo.
    */
   public getSiteExists = async (siteID: string): Promise<AxiosResponse<{ result: boolean; epaSiteId: string }>> => {
+    this.validateSiteID(siteID);
     return this.apiClient.get(`v1/site-exists/${siteID}`);
   };
 
@@ -363,10 +365,11 @@ class RcraClient {
 
   /**
    * Performs 'quicker' signature for the entity within the manifest specified by given
-   * siteId and siteType. If siteType is 'Transporter', transporter order must be specified to
+   * siteID and siteType. If siteType is 'Transporter', transporter order must be specified to
    * indicate which transporter performs the signature.
    */
   public SignManifest = async (parameters: QuickerSign): Promise<AxiosResponse<any>> => {
+    this.validateSiteID(parameters.siteID);
     return this.apiClient.post('v1/emanifest/manifest/quicker-sign', parameters);
   };
 
@@ -374,4 +377,13 @@ class RcraClient {
   // public correctManifest = async (): Promise<AxiosResponse<any>> => {
   //   return this.apiClient.post('v1/emanifest/manifest/correct');
   // };
+
+  private validateSiteID = (siteID: string): void => {
+    if (!siteID || siteID === '') {
+      throw new Error('Site ID cannot be empty');
+    }
+    if (siteID.length !== 12) {
+      throw new Error('Site ID must be 12 characters long');
+    }
+  };
 }

--- a/emanifest-js/src/client.ts
+++ b/emanifest-js/src/client.ts
@@ -30,6 +30,7 @@ interface RcraClientConfig {
   apiID?: string;
   apiKey?: string;
   authAuth?: Boolean;
+  validateInput?: Boolean;
 }
 
 export type RcraClientClass = typeof RcraClient;
@@ -41,8 +42,14 @@ export type RcraClientClass = typeof RcraClient;
  * @param apiKey - The API key for the RCRAInfo.
  * @param authAuth - Automatically authenticate if necessary. By default, this is disabled.
  */
-export const newClient = ({ apiBaseURL, apiID, apiKey, authAuth = false }: RcraClientConfig = {}) => {
-  return new RcraClient(apiBaseURL, apiID, apiKey, authAuth);
+export const newClient = ({
+  apiBaseURL,
+  apiID,
+  apiKey,
+  authAuth = false,
+  validateInput = false,
+}: RcraClientConfig = {}) => {
+  return new RcraClient(apiBaseURL, apiID, apiKey, authAuth, validateInput);
 };
 
 /**
@@ -62,12 +69,20 @@ class RcraClient {
   token?: string;
   expiration?: string;
   autoAuth?: Boolean;
+  validateInput?: Boolean;
 
-  constructor(apiBaseURL: RcrainfoEnv, apiID?: string, apiKey?: string, autoAuth: Boolean = false) {
+  constructor(
+    apiBaseURL: RcrainfoEnv,
+    apiID?: string,
+    apiKey?: string,
+    autoAuth: Boolean = false,
+    validateInput: Boolean = false,
+  ) {
     this.env = apiBaseURL || RCRAINFO_PREPROD;
     this.apiID = apiID;
     this.apiKey = apiKey;
     this.autoAuth = autoAuth;
+    this.validateInput = validateInput;
     this.apiClient = axios.create({
       baseURL: this.env,
       headers: {

--- a/emanifest-js/src/client.ts
+++ b/emanifest-js/src/client.ts
@@ -145,7 +145,9 @@ class RcraClient {
    * @param stateCode
    */
   public getStateWasteCodes = async (stateCode: string): Promise<AxiosResponse<RcraCode[]>> => {
-    this.validateStateCode(stateCode);
+    if (this.validateInput) {
+      this.validateStateCode(stateCode);
+    }
     return this.apiClient.get(`v1/lookup/state-waste-codes/${stateCode}`);
   };
 
@@ -245,7 +247,9 @@ class RcraClient {
    * Get a site by its EPA ID.
    */
   public getSite = async (siteID: string): Promise<AxiosResponse> => {
-    this.validateSiteID(siteID);
+    if (this.validateInput) {
+      this.validateSiteID(siteID);
+    }
     return this.apiClient.get(`v1/site-details/${siteID}`);
   };
 
@@ -253,7 +257,9 @@ class RcraClient {
    * Returns true if the site, by EPA ID, exists in RCRAInfo.
    */
   public getSiteExists = async (siteID: string): Promise<AxiosResponse<{ result: boolean; epaSiteId: string }>> => {
-    this.validateSiteID(siteID);
+    if (this.validateInput) {
+      this.validateSiteID(siteID);
+    }
     return this.apiClient.get(`v1/site-exists/${siteID}`);
   };
 
@@ -308,7 +314,9 @@ class RcraClient {
    * @param manifestTrackingNumber
    */
   public deleteManifest = async (manifestTrackingNumber: string): Promise<AxiosResponse<any>> => {
-    this.validateMTN(manifestTrackingNumber);
+    if (this.validateInput) {
+      this.validateMTN(manifestTrackingNumber);
+    }
     return this.apiClient.delete(`v1/emanifest/manifest/delete${manifestTrackingNumber}`);
   };
 
@@ -326,7 +334,9 @@ class RcraClient {
    * Retrieve information about all manifest correction versions by manifest tracking number
    */
   public getManifestCorrections = async (manifestTrackingNumber: string): Promise<AxiosResponse<any>> => {
-    this.validateMTN(manifestTrackingNumber);
+    if (this.validateInput) {
+      this.validateMTN(manifestTrackingNumber);
+    }
     return this.apiClient.get(`v1/emanifest/manifest/correction-details/${manifestTrackingNumber}`);
   };
 
@@ -352,7 +362,9 @@ class RcraClient {
    * Retrieve Manifest Tracking Numbers for provided site id.
    */
   public getSiteMTN = async (siteID: string): Promise<AxiosResponse<string[]>> => {
-    this.validateSiteID(siteID);
+    if (this.validateInput) {
+      this.validateSiteID(siteID);
+    }
     return this.apiClient.get(`v1/emanifest/manifest-tracking-numbers/${siteID}`);
   };
 
@@ -366,8 +378,10 @@ class RcraClient {
     stateCode: string;
     siteType: string;
   }): Promise<AxiosResponse<any>> => {
-    this.validateSiteType(siteType);
-    this.validateStateCode(stateCode);
+    if (this.validateInput) {
+      this.validateSiteType(siteType);
+      this.validateStateCode(stateCode);
+    }
     return this.apiClient.get(`v1/emanifest/site-ids/${stateCode}/${siteType}`);
   };
 
@@ -375,7 +389,9 @@ class RcraClient {
    * Retrieve e-Manifest by provided manifest tracking number.
    */
   public getManifest = async (manifestTrackingNumber: string): Promise<AxiosResponse<any>> => {
-    this.validateMTN(manifestTrackingNumber);
+    if (this.validateInput) {
+      this.validateMTN(manifestTrackingNumber);
+    }
     return this.apiClient.get(`v1/emanifest/manifest/${manifestTrackingNumber}`);
   };
 
@@ -383,15 +399,17 @@ class RcraClient {
    * Retrieve manifest tracking numbers based on provided search criteria in JSON format.
    */
   public searchManifest = async (parameters: ManifestSearchParameters): Promise<AxiosResponse<any>> => {
-    // Many of the search parameters are optional, we only want to validate them if they are provided.
-    if (parameters.dateType) {
-      this.validateDateType(parameters.dateType);
-    }
-    if (parameters.stateCode) {
-      this.validateStateCode(parameters.stateCode);
-    }
-    if (parameters.siteType) {
-      this.validateSiteType(parameters.siteType);
+    if (this.validateInput) {
+      // Many of the search parameters are optional, we only want to validate them if they are provided.
+      if (parameters.dateType) {
+        this.validateDateType(parameters.dateType);
+      }
+      if (parameters.stateCode) {
+        this.validateStateCode(parameters.stateCode);
+      }
+      if (parameters.siteType) {
+        this.validateSiteType(parameters.siteType);
+      }
     }
     return this.apiClient.post('v1/emanifest/manifest/search', parameters);
   };
@@ -407,7 +425,9 @@ class RcraClient {
    * Revert manifest in 'UnderCorrection' status to previous 'Corrected' or 'Signed' version.
    */
   public revertManifest = async (manifestTrackingNumber: string): Promise<AxiosResponse<any>> => {
-    this.validateMTN(manifestTrackingNumber);
+    if (this.validateInput) {
+      this.validateMTN(manifestTrackingNumber);
+    }
     return this.apiClient.get(`v1/emanifest/manifest/revert/${manifestTrackingNumber}`);
   };
 
@@ -417,8 +437,10 @@ class RcraClient {
    * indicate which transporter performs the signature.
    */
   public SignManifest = async (parameters: QuickerSign): Promise<AxiosResponse<any>> => {
-    this.validateSiteID(parameters.siteID);
-    this.validateSiteType(parameters.siteType);
+    if (this.validateInput) {
+      this.validateSiteID(parameters.siteID);
+      this.validateSiteType(parameters.siteType);
+    }
     return this.apiClient.post('v1/emanifest/manifest/quicker-sign', parameters);
   };
 

--- a/emanifest-js/src/client.ts
+++ b/emanifest-js/src/client.ts
@@ -124,6 +124,9 @@ class RcraClient {
    * @param stateCode
    */
   public getStateWasteCodes = async (stateCode: string): Promise<AxiosResponse<RcraCode[]>> => {
+    if (stateCode.length !== 2) {
+      throw new Error('stateCode must be two characters long');
+    }
     return this.apiClient.get(`v1/lookup/state-waste-codes/${stateCode}`);
   };
 

--- a/emanifest-js/src/client.ts
+++ b/emanifest-js/src/client.ts
@@ -454,37 +454,37 @@ class RcraClient {
       throw new Error('Site ID cannot be empty');
     }
     if (siteID.length !== 12) {
-      throw new Error('Site ID must be 12 characters long');
+      throw new Error('siteID must be a string of length 12');
     }
   };
 
   private validateMTN = (manifestTrackingNumber: string): void => {
     if (!manifestTrackingNumber || manifestTrackingNumber === '') {
-      throw new Error('Site ID cannot be empty');
+      throw new Error('manifestTrackingNumber cannot be empty');
     }
     if (manifestTrackingNumber.length !== 12) {
-      throw new Error('Site ID must be 12 characters long');
+      throw new Error('manifestTrackingNumber must be a string of length 12');
     }
   };
 
   private validateStateCode = (stateCode: string): void => {
     if (!stateCode || stateCode === '') {
-      throw new Error('State code cannot be empty');
+      throw new Error('StateCode cannot be empty');
     }
     if (stateCode.length !== 2) {
-      throw new Error('State code must be 2 characters long');
+      throw new Error('StateCode must be 2 characters long');
     }
   };
 
   private validateSiteType = (siteType: SiteType): void => {
     if (!siteTypeValues.includes(siteType)) {
-      throw new Error(`Site types must be ${siteTypeValues}`);
+      throw new Error(`SiteType must be one of ${siteTypeValues}`);
     }
   };
 
   private validateDateType = (dateType: DateType): void => {
     if (!dateTypeValues.includes(dateType)) {
-      throw new Error(`Site types must be ${dateTypeValues}`);
+      throw new Error(`dateType must be one of ${dateTypeValues}`);
     }
   };
 }

--- a/emanifest-js/src/index.ts
+++ b/emanifest-js/src/index.ts
@@ -18,12 +18,14 @@ import {
   ManifestStatus,
   SubmissionType,
   PackingGroups,
+  DateType,
 } from './types';
 
 export { RCRAINFO_PREPROD, RCRAINFO_PROD, newClient };
 export type {
   AuthResponse,
   BillGetParameters,
+  DateType,
   BillHistoryParameters,
   BillSearchParameters,
   ManifestCorrectionParameters,

--- a/emanifest-js/src/tests/client.spec.ts
+++ b/emanifest-js/src/tests/client.spec.ts
@@ -58,6 +58,10 @@ describe('RcraClient', () => {
         console.log('error', err);
       });
   });
+  it('RcraClient returns an error if stateCode is not two characters long', async () => {
+    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
+    await expect(() => rcrainfo.getStateWasteCodes('BAD_STATE_CODE')).rejects.toThrowError(/two characters/);
+  });
 });
 
 describe('emanifest package', () => {

--- a/emanifest-js/src/tests/client.spec.ts
+++ b/emanifest-js/src/tests/client.spec.ts
@@ -60,7 +60,7 @@ describe('RcraClient', () => {
   });
 });
 
-describe('RcraClient Validates before calling API', () => {
+describe('RcraClient input validation', () => {
   it('throws an error if stateCode is not two characters long', async () => {
     const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
     await expect(() => rcrainfo.getStateWasteCodes('BAD_STATE_CODE')).rejects.toThrowError(/two characters/);
@@ -75,6 +75,10 @@ describe('RcraClient Validates before calling API', () => {
     // @ts-ignore
     await expect(() => rcrainfo.getSite()).rejects.toThrowError();
     await expect(() => rcrainfo.getSite('')).rejects.toThrowError();
+  });
+  it('throws an error if siteType is not one of acceptable enums', async () => {
+    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
+    await expect(() => rcrainfo.getStateSites({ stateCode: 'VA', siteType: 'bad_site_type' })).rejects.toThrowError();
   });
 });
 

--- a/emanifest-js/src/tests/client.spec.ts
+++ b/emanifest-js/src/tests/client.spec.ts
@@ -68,9 +68,9 @@ describe('RcraClient validation', () => {
   it('throws an error if siteID is not 12 characters long', async () => {
     const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD, validateInput: true });
     await expect(() => rcrainfo.getSite('lengthy_site_id_yo_yo')).rejects.toThrowError(
-      'Site ID must be 12 characters long',
+      'siteID must be a string of length 12',
     );
-    await expect(() => rcrainfo.getSite('12345')).rejects.toThrowError('Site ID must be 12 characters long');
+    await expect(() => rcrainfo.getSite('12345')).rejects.toThrowError('siteID must be a string of length 12');
   });
   it('throws an error if siteID is empty', async () => {
     const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD, validateInput: true });

--- a/emanifest-js/src/tests/client.spec.ts
+++ b/emanifest-js/src/tests/client.spec.ts
@@ -60,10 +60,10 @@ describe('RcraClient', () => {
   });
 });
 
-describe('RcraClient input validation', () => {
+describe('RcraClient validation', () => {
   it('throws an error if stateCode is not two characters long', async () => {
     const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
-    await expect(() => rcrainfo.getStateWasteCodes('BAD_STATE_CODE')).rejects.toThrowError(/two characters/);
+    await expect(() => rcrainfo.getStateWasteCodes('BAD_STATE_CODE')).rejects.toThrowError();
   });
   it('throws an error if siteID is not 12 characters long', async () => {
     const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });

--- a/emanifest-js/src/tests/client.spec.ts
+++ b/emanifest-js/src/tests/client.spec.ts
@@ -58,9 +58,23 @@ describe('RcraClient', () => {
         console.log('error', err);
       });
   });
-  it('RcraClient returns an error if stateCode is not two characters long', async () => {
+});
+
+describe('RcraClient Validates before calling API', () => {
+  it('throws an error if stateCode is not two characters long', async () => {
     const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
     await expect(() => rcrainfo.getStateWasteCodes('BAD_STATE_CODE')).rejects.toThrowError(/two characters/);
+  });
+  it('throws an error if siteID is not 12 characters long', async () => {
+    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
+    await expect(() => rcrainfo.getSite('lengthy_site_id_yo_yo')).rejects.toThrowError();
+    await expect(() => rcrainfo.getSite('short_id')).rejects.toThrowError();
+  });
+  it('throws an error if siteID is empty', async () => {
+    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
+    // @ts-ignore
+    await expect(() => rcrainfo.getSite()).rejects.toThrowError();
+    await expect(() => rcrainfo.getSite('')).rejects.toThrowError();
   });
 });
 

--- a/emanifest-js/src/tests/client.spec.ts
+++ b/emanifest-js/src/tests/client.spec.ts
@@ -67,13 +67,15 @@ describe('RcraClient validation', () => {
   });
   it('throws an error if siteID is not 12 characters long', async () => {
     const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
-    await expect(() => rcrainfo.getSite('lengthy_site_id_yo_yo')).rejects.toThrowError();
-    await expect(() => rcrainfo.getSite('short_id')).rejects.toThrowError();
+    await expect(() => rcrainfo.getSite('lengthy_site_id_yo_yo')).rejects.toThrowError(
+      'Site ID must be 12 characters long',
+    );
+    await expect(() => rcrainfo.getSite('12345')).rejects.toThrowError('Site ID must be 12 characters long');
   });
   it('throws an error if siteID is empty', async () => {
     const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
     // @ts-ignore
-    await expect(() => rcrainfo.getSite()).rejects.toThrowError();
+    await expect(() => rcrainfo.getSite()).rejects.toThrowError('Site ID cannot be empty');
     await expect(() => rcrainfo.getSite('')).rejects.toThrowError();
   });
   it('throws an error if siteType is not one of acceptable enums', async () => {

--- a/emanifest-js/src/tests/client.spec.ts
+++ b/emanifest-js/src/tests/client.spec.ts
@@ -62,24 +62,24 @@ describe('RcraClient', () => {
 
 describe('RcraClient validation', () => {
   it('throws an error if stateCode is not two characters long', async () => {
-    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
+    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD, validateInput: true });
     await expect(() => rcrainfo.getStateWasteCodes('BAD_STATE_CODE')).rejects.toThrowError();
   });
   it('throws an error if siteID is not 12 characters long', async () => {
-    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
+    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD, validateInput: true });
     await expect(() => rcrainfo.getSite('lengthy_site_id_yo_yo')).rejects.toThrowError(
       'Site ID must be 12 characters long',
     );
     await expect(() => rcrainfo.getSite('12345')).rejects.toThrowError('Site ID must be 12 characters long');
   });
   it('throws an error if siteID is empty', async () => {
-    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
+    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD, validateInput: true });
     // @ts-ignore
     await expect(() => rcrainfo.getSite()).rejects.toThrowError('Site ID cannot be empty');
     await expect(() => rcrainfo.getSite('')).rejects.toThrowError();
   });
   it('throws an error if siteType is not one of acceptable enums', async () => {
-    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD });
+    const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD, validateInput: true });
     await expect(() => rcrainfo.getStateSites({ stateCode: 'VA', siteType: 'bad_site_type' })).rejects.toThrowError();
   });
 });

--- a/emanifest-js/src/tests/client.spec.ts
+++ b/emanifest-js/src/tests/client.spec.ts
@@ -1,5 +1,5 @@
 import { AxiosError, AxiosResponse } from 'axios';
-import { MOCK_API_ID, MOCK_API_KEY, MOCK_PACKING_GROUPS, MOCK_TOKEN } from './mockConstants';
+import { MOCK_API_ID, MOCK_API_KEY, MOCK_BAD_SITE_ID, MOCK_PACKING_GROUPS, MOCK_TOKEN } from './mockConstants';
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { newClient, RCRAINFO_PREPROD, RCRAINFO_PROD } from '../index';
 // @ts-ignore
@@ -61,6 +61,15 @@ describe('RcraClient', () => {
 });
 
 describe('RcraClient validation', () => {
+  it('is disabled by default', async () => {
+    const rcrainfo = newClient({
+      apiBaseURL: RCRAINFO_PREPROD,
+      apiID: MOCK_API_ID,
+      apiKey: MOCK_API_KEY,
+      authAuth: true,
+    });
+    await expect(() => rcrainfo.getSite(MOCK_BAD_SITE_ID)).rejects.toThrowError();
+  });
   it('throws an error if stateCode is not two characters long', async () => {
     const rcrainfo = newClient({ apiBaseURL: RCRAINFO_PREPROD, validateInput: true });
     await expect(() => rcrainfo.getStateWasteCodes('BAD_STATE_CODE')).rejects.toThrowError();

--- a/emanifest-js/src/tests/mockConstants.ts
+++ b/emanifest-js/src/tests/mockConstants.ts
@@ -2,3 +2,4 @@ export const MOCK_API_ID = 'mockApiId';
 export const MOCK_API_KEY = 'mockApiKey';
 export const MOCK_TOKEN = 'mockToken';
 export const MOCK_PACKING_GROUPS = ['I', 'II', 'III'];
+export const MOCK_BAD_SITE_ID = 'badID';

--- a/emanifest-js/src/tests/mocks/handlers.js
+++ b/emanifest-js/src/tests/mocks/handlers.js
@@ -1,5 +1,5 @@
 import { rest } from 'msw';
-import { MOCK_API_ID, MOCK_API_KEY, MOCK_PACKING_GROUPS, MOCK_TOKEN } from '../mockConstants';
+import { MOCK_API_ID, MOCK_API_KEY, MOCK_BAD_SITE_ID, MOCK_PACKING_GROUPS, MOCK_TOKEN } from '../mockConstants';
 import { RCRAINFO_PREPROD } from '../../client';
 
 export const handlers = [
@@ -15,6 +15,21 @@ export const handlers = [
   rest.get(`${RCRAINFO_PREPROD}/v1/emanifest/lookup/packing-groups`, (req, res, ctx) => {
     if (req.headers.get('Authorization') === `Bearer ${MOCK_TOKEN}`) {
       return res(ctx.status(200), ctx.json(MOCK_PACKING_GROUPS));
+    }
+    return res(ctx.status(401));
+  }),
+  // Request for a bad site ID (likely a better way to parameterize this)
+  rest.get(`${RCRAINFO_PREPROD}/v1/site-details/${MOCK_BAD_SITE_ID}`, (req, res, ctx) => {
+    if (req.headers.get('Authorization') === `Bearer ${MOCK_TOKEN}`) {
+      return res(
+        ctx.status(400),
+        ctx.json({
+          code: 'E_SiteIdNotFound',
+          message: 'Site with Provided Site id is Not Found',
+          errorId: '41cb95ed-f477-41aa-83af-fc4a28efbfa5',
+          errorDate: '2023-08-11T18:10:45.979+00:00',
+        }),
+      );
     }
     return res(ctx.status(401));
   }),

--- a/emanifest-js/src/types.ts
+++ b/emanifest-js/src/types.ts
@@ -21,6 +21,9 @@ export type OriginType = 'Web' | 'Service' | 'Mail';
 export const siteTypeValues = ['Generator', 'Tsdf', 'Transporter', 'Rejection_AlternateTsdf'];
 export type SiteType = (typeof siteTypeValues)[number];
 
+export const dateTypeValues = ['CertifiedDate', 'ReceivedDate', 'ShippedDate', 'UpdatedDate'];
+export type DateType = (typeof dateTypeValues)[number];
+
 /**
  * structure of many codes used by the manifest (waste codes, management methods codes, etc.)
  */
@@ -86,7 +89,7 @@ export interface ManifestSearchParameters {
   stateCode: string;
   siteId: string;
   status: ManifestStatus;
-  dateType: 'CertifiedDate' | 'ReceivedDate' | 'ShippedDate' | 'UpdatedDate';
+  dateType: DateType;
   siteType: SiteType;
   startDate: string;
   endDate: string;

--- a/emanifest-js/src/types.ts
+++ b/emanifest-js/src/types.ts
@@ -18,7 +18,8 @@ export type ManifestStatus =
 export type SubmissionType = 'FullElectronic' | 'DataImage5Copy' | 'Hybrid' | 'Image';
 export type OriginType = 'Web' | 'Service' | 'Mail';
 
-export type SiteType = 'Generator' | 'Tsdf' | 'Transporter' | 'Rejection_AlternateTsdf';
+export const siteTypeValues = ['Generator', 'Tsdf', 'Transporter', 'Rejection_AlternateTsdf'];
+export type SiteType = (typeof siteTypeValues)[number];
 
 /**
  * structure of many codes used by the manifest (waste codes, management methods codes, etc.)

--- a/emanifest-js/src/types.ts
+++ b/emanifest-js/src/types.ts
@@ -102,7 +102,7 @@ export interface ManifestExistsResponse {
 
 export interface QuickerSign {
   manifestTrackingNumbers: string[];
-  siteId: string;
+  siteID: string;
   siteType: SiteType;
   printedSignatureName: string;
   printedSignatureDate: string;


### PR DESCRIPTION
This PR marks the v0.2.0 release of the emanifest NPM package. 

In this release, we've added option user input validations. Like the autoAuth feature, this behavior is disabled by deafult, but available for interested parties. The update includes unit test proving the validations work. the PR also updates the documentation (README.md). 