### PR TITLE
Bugfix for get_handler method

### DIFF
--- a/emanifest-py/pyproject.toml
+++ b/emanifest-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "emanifest"
-version = "4.0.1"
+version = "4.0.2"
 description = "An API utility wrapper for accessing the e-Manifest hazardous waste tracking system maintained by the US Environmental Protection Agency"
 readme = "README.md"
 authors = [

--- a/emanifest-py/src/emanifest/client.py
+++ b/emanifest-py/src/emanifest/client.py
@@ -1061,7 +1061,7 @@ class RcrainfoClient(Session):
         Returns:
             dict: object containing handler source records (and optional details)
         """
-        endpoint = f"v1/state/handler/sources/{handler_id}/{str(details)}"
+        endpoint = f"{self.base_url}v1/state/handler/sources/{handler_id}/{str(details)}"
         return self.__rcra_request("GET", endpoint)
 
 


### PR DESCRIPTION
get_handler method didn't have {self.base_url} in the endpoint.