### PR TITLE
Sample client UI

### DIFF
--- a/sample-client/README.md
+++ b/sample-client/README.md
@@ -17,12 +17,13 @@ an account in the Pre-Production environment with an API ID and Key.
     ```shell
     ./mvnw spring-boot:run
     ```
-3. Make a curl request or use a browser to access the application
+3. Make a request to the client API
     ```shell
     curl http://localhost:8080/api/lookup/container-types
     ```
+   or visit the sample client local UI at http://localhost:8080
 
-## Help
+## Spring Boot Help
 
 ### Reference Documentation
 

--- a/sample-client/compose.yaml
+++ b/sample-client/compose.yaml
@@ -1,9 +1,0 @@
-services:
-  postgres:
-    image: 'postgres:latest'
-    environment:
-      - 'POSTGRES_DB=mydatabase'
-      - 'POSTGRES_PASSWORD=secret'
-      - 'POSTGRES_USER=myuser'
-    ports:
-      - '5432'

--- a/sample-client/pom.xml
+++ b/sample-client/pom.xml
@@ -33,12 +33,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-docker-compose</artifactId>
-            <scope>runtime</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>

--- a/sample-client/pom.xml
+++ b/sample-client/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/sample-client/src/main/java/gov/epa/rcra/rest/Home.java
+++ b/sample-client/src/main/java/gov/epa/rcra/rest/Home.java
@@ -1,14 +1,26 @@
 package gov.epa.rcra.rest;
 
+import gov.epa.rcra.rest.auth.AuthClient;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import java.time.ZonedDateTime;
+
 @Controller
 public class Home {
 
+    private final AuthClient authClient;
+
+    public Home(AuthClient authClient) {
+        this.authClient = authClient;
+    }
+
+
     @GetMapping("/")
     public String home(Model model) {
+        ZonedDateTime tokenExpiration = authClient.getTokenExpiration();
+        model.addAttribute("tokenExpiration", tokenExpiration.toString());
         model.addAttribute("theDate", "Hello");
         return "index";
     }

--- a/sample-client/src/main/java/gov/epa/rcra/rest/Home.java
+++ b/sample-client/src/main/java/gov/epa/rcra/rest/Home.java
@@ -1,0 +1,16 @@
+package gov.epa.rcra.rest;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class Home {
+
+    @GetMapping("/")
+    public String home(Model model) {
+        model.addAttribute("theDate", "Hello");
+        return "index";
+    }
+
+}

--- a/sample-client/src/main/java/gov/epa/rcra/rest/auth/AuthClient.java
+++ b/sample-client/src/main/java/gov/epa/rcra/rest/auth/AuthClient.java
@@ -6,6 +6,8 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import java.time.ZonedDateTime;
+
 @Component
 public class AuthClient {
 
@@ -16,9 +18,14 @@ public class AuthClient {
 
     @Value("${rcrainfo.api-id}")
     private String apiId;
+    private ZonedDateTime tokenExpiration;
 
     AuthClient(RcraClientConfiguration rcraClientConfiguration) {
         this.client = rcraClientConfiguration.getClient();
+    }
+
+    public ZonedDateTime getTokenExpiration() {
+        return tokenExpiration;
     }
 
     public RestClient authenticate() {
@@ -30,6 +37,7 @@ public class AuthClient {
         if (data == null) {
             throw new RuntimeException("Failed to authenticate");
         }
+        tokenExpiration = data.expiration();
         return client.mutate()
                 .defaultHeader("Authorization", "Bearer " + data.token()).build();
     }

--- a/sample-client/src/main/resources/static/rcrainfoServices.js
+++ b/sample-client/src/main/resources/static/rcrainfoServices.js
@@ -1,0 +1,75 @@
+// Copy button toast notification
+document.addEventListener('DOMContentLoaded', () => {
+    // Initialize toast
+    const toastElList = [].slice.call(document.querySelectorAll('.toast'));
+    const toastList = toastElList.map(function (toastEl) {
+        return new bootstrap.Toast(toastEl)
+    });
+
+    // Add event listener to copy buttons
+    const copyButtons = document.querySelectorAll('.btn-secondary');
+    copyButtons.forEach(function (button) {
+        button.addEventListener('click', function () {
+            toastList.forEach(function (toast) {
+                toast.show();
+            });
+        });
+    });
+});
+
+class ApiClient {
+
+    static fetchSiteExists = (epaId) => {
+        return async () => {
+            return await this.#fetchData(`http://localhost:8080/api/site/${epaId}/exists`);
+        }
+    }
+
+    static fetchSite = (epaId) => {
+        return async () => {
+            return await this.#fetchData(`http://localhost:8080/api/site/${epaId}`);
+        }
+    }
+    static fetchLookup = (lookup) => {
+        return async () => {
+            return await this.#fetchData(`http://localhost:8080/api/lookup/${lookup}`);
+        }
+    }
+
+    static #fetchData = async (url) => {
+        const response = await fetch(url);
+        if (response.status >= 400) {
+            alert('Error fetching data');
+            return;
+        }
+        return await response.json();
+    }
+
+    static #displayData = (elementId, data) => {
+        document.getElementById(elementId).value = JSON.stringify(data, null, 2);
+    }
+}
+
+
+function copyToClipboard(elementId) {
+    const copyText = document.getElementById(elementId);
+    navigator.clipboard.writeText(copyText.value);
+}
+
+function startCountdown(dateString) {
+    const countDownDate = new Date(dateString).getTime();
+
+    const countdownFunction = setInterval(function () {
+        const now = new Date().getTime();
+        const distance = countDownDate - now;
+        const minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
+        const seconds = Math.floor((distance % (1000 * 60)) / 1000);
+
+        document.getElementById("countdown").innerText = minutes + "m " + seconds + "s ";
+
+        if (distance < 0) {
+            clearInterval(countdownFunction);
+            document.getElementById("countdown").innerText = "EXPIRED"
+        }
+    }, 1000);
+}

--- a/sample-client/src/main/resources/templates/index.html
+++ b/sample-client/src/main/resources/templates/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>e-Manifest Sample Client</title>
+</head>
+<body>
+<h1>e-Manifest Sample Client</h1>
+<div>
+    <h2>Lookup Services</h2>
+    <label for="endpoints">Select Lookup</label>
+    <select id="endpoints">
+        <option value="container-types">Container Types</option>
+        <option value="waste-minimization-codes">Waste Minimization Codes</option>
+        <option value="source-codes">Source Codes</option>
+        <option value="management-method-codes">Management Method Codes</option>
+        <option value="density-codes">Density Codes</option>
+        <option value="form-codes">Form Codes</option>
+        <option value="federal-waste-codes">Federal Waste Codes</option>
+        <option value="state-waste-codes">State Waste Codes</option>
+    </select>
+    <button onclick="fetchData()">Fetch Data</button>
+    <textarea id="jsonOutput" style="width: 100%; height: 500px;"></textarea>
+</div>
+
+
+<div>
+    <h2>Site Services</h2>
+    <label for="siteServiceSelection">Select Site Service</label>
+    <select id="siteServiceSelection">
+        <option value="getSite">Get Site</option>
+        <option value="getSiteExists">Get Site Exists</option>
+    </select>
+    <label for="siteEpaId">Enter Site EPA ID</label>
+    <input id="siteEpaId" type="text"/>
+    <button onclick="fetchSiteData()">Fetch Site Data</button>
+    <textarea id="siteJsonOutput" style="width: 100%; height: 500px;"></textarea>
+</div>
+<script>
+    async function fetchSiteData() {
+        const endpoint = document.getElementById('siteServiceSelection').value;
+        const epaId = document.getElementById('siteEpaId').value;
+        let url = `http://localhost:8080/api/site/${epaId}`;
+        if (endpoint === 'getSiteExists') {
+            url = `${url}/exists`;
+        }
+        const response = await fetch(url);
+        const data = await response.json();
+        document.getElementById('siteJsonOutput').value = JSON.stringify(data, null, 2);
+    }
+</script>
+
+
+</body>
+</html>
+<script>
+    async function fetchData() {
+        const endpoint = document.getElementById('endpoints').value;
+        const response = await fetch(`http://localhost:8080/api/lookup/${endpoint}`);
+        const data = await response.json();
+        document.getElementById('jsonOutput').value = JSON.stringify(data, null, 2);
+    }
+</script>

--- a/sample-client/src/main/resources/templates/index.html
+++ b/sample-client/src/main/resources/templates/index.html
@@ -2,39 +2,61 @@
 <html lang="en">
 <head>
     <title>e-Manifest Sample Client</title>
+    <!-- Add Bootstrap CSS -->
+    <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" rel="stylesheet">
+    <script crossorigin="anonymous"
+            integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+            src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </head>
-<body>
-<h1>e-Manifest Sample Client</h1>
-<div>
-    <h2>Lookup Services</h2>
-    <label for="endpoints">Select Lookup</label>
-    <select id="endpoints">
-        <option value="container-types">Container Types</option>
-        <option value="waste-minimization-codes">Waste Minimization Codes</option>
-        <option value="source-codes">Source Codes</option>
-        <option value="management-method-codes">Management Method Codes</option>
-        <option value="density-codes">Density Codes</option>
-        <option value="form-codes">Form Codes</option>
-        <option value="federal-waste-codes">Federal Waste Codes</option>
-        <option value="state-waste-codes">State Waste Codes</option>
-    </select>
-    <button onclick="fetchData()">Fetch Data</button>
-    <textarea id="jsonOutput" style="width: 100%; height: 500px;"></textarea>
+<body class="bg-light">
+<div class="container">
+    <h1>e-Manifest Sample Client</h1>
+    <div class="my-3">
+        <h2>Lookup Services</h2>
+        <div class="row d-flex align-items-end justify-content-around mb-3">
+            <div class="col-9">
+                <label for="endpoints">Select Lookup</label>
+                <select class="form-select" id="endpoints">
+                    <option value="container-types">Container Types</option>
+                    <option value="waste-minimization-codes">Waste Minimization Codes</option>
+                    <option value="source-codes">Source Codes</option>
+                    <option value="management-method-codes">Management Method Codes</option>
+                    <option value="density-codes">Density Codes</option>
+                    <option value="form-codes">Form Codes</option>
+                    <option value="federal-waste-codes">Federal Waste Codes</option>
+                    <option value="state-waste-codes">State Waste Codes</option>
+                </select>
+            </div>
+            <div class="col-3 d-flex justify-content-end">
+                <button class="btn btn-primary" onclick="fetchData()">Fetch Data</button>
+            </div>
+        </div>
+        <textarea class="form-control" id="jsonOutput" style="width: 100%; height: 500px;"></textarea>
+    </div>
+    <div class="my-3">
+        <h2>Site Services</h2>
+        <div class="row d-flex align-items-end mb-3">
+            <div class="col-3">
+                <label for="siteServiceSelection">Select Site Service</label>
+                <select class="form-select" id="siteServiceSelection">
+                    <option value="getSite">Get Site</option>
+                    <option value="getSiteExists">Get Site Exists</option>
+                </select>
+            </div>
+            <div class="col-6">
+                <label for="siteEpaId">Enter Site EPA ID</label>
+                <input class="form-control" id="siteEpaId" type="text"/>
+            </div>
+            <div class="col-3 d-flex justify-content-end">
+                <button class="btn btn-primary" onclick="fetchSiteData()">Fetch Site Data</button>
+            </div>
+        </div>
+        <textarea class="form-control" id="siteJsonOutput" style="width: 100%; height: 500px;"></textarea>
+    </div>
 </div>
-
-
-<div>
-    <h2>Site Services</h2>
-    <label for="siteServiceSelection">Select Site Service</label>
-    <select id="siteServiceSelection">
-        <option value="getSite">Get Site</option>
-        <option value="getSiteExists">Get Site Exists</option>
-    </select>
-    <label for="siteEpaId">Enter Site EPA ID</label>
-    <input id="siteEpaId" type="text"/>
-    <button onclick="fetchSiteData()">Fetch Site Data</button>
-    <textarea id="siteJsonOutput" style="width: 100%; height: 500px;"></textarea>
-</div>
+</body>
+</html>
 <script>
     async function fetchSiteData() {
         const endpoint = document.getElementById('siteServiceSelection').value;
@@ -47,12 +69,7 @@
         const data = await response.json();
         document.getElementById('siteJsonOutput').value = JSON.stringify(data, null, 2);
     }
-</script>
 
-
-</body>
-</html>
-<script>
     async function fetchData() {
         const endpoint = document.getElementById('endpoints').value;
         const response = await fetch(`http://localhost:8080/api/lookup/${endpoint}`);

--- a/sample-client/src/main/resources/templates/index.html
+++ b/sample-client/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>e-Manifest Sample Client</title>
     <!-- Add Bootstrap CSS -->
@@ -11,69 +11,130 @@
 </head>
 <body class="bg-light">
 <div class="container">
-    <h1>e-Manifest Sample Client</h1>
     <div class="my-3">
-        <h2>Lookup Services</h2>
-        <div class="row d-flex align-items-end justify-content-around mb-3">
+        <div class="row">
             <div class="col-9">
-                <label for="endpoints">Select Lookup</label>
-                <select class="form-select" id="endpoints">
-                    <option value="container-types">Container Types</option>
-                    <option value="waste-minimization-codes">Waste Minimization Codes</option>
-                    <option value="source-codes">Source Codes</option>
-                    <option value="management-method-codes">Management Method Codes</option>
-                    <option value="density-codes">Density Codes</option>
-                    <option value="form-codes">Form Codes</option>
-                    <option value="federal-waste-codes">Federal Waste Codes</option>
-                    <option value="state-waste-codes">State Waste Codes</option>
-                </select>
+                <h1>e-Manifest Sample Client</h1>
             </div>
-            <div class="col-3 d-flex justify-content-end">
-                <button class="btn btn-primary" onclick="fetchData()">Fetch Data</button>
+            <div class="col-3">
+                <p>Token expiration: <span id="countdown"></span></p>
             </div>
         </div>
-        <textarea class="form-control" id="jsonOutput" style="width: 100%; height: 500px;"></textarea>
+    </div>
+    <div class="my-3">
+        <h2>Lookup Services</h2>
+        <form action="javascript:executeService('lookup')">
+            <div class="row d-flex align-items-end justify-content-around mb-3">
+                <div class="col-9">
+                    <label for="lookupService">Select Lookup</label>
+                    <select class="form-select" id="lookupService" required>
+                        <option value="container-types">Container Types</option>
+                        <option value="waste-minimization-codes">Waste Minimization Codes</option>
+                        <option value="source-codes">Source Codes</option>
+                        <option value="management-method-codes">Management Method Codes</option>
+                        <option value="density-codes">Density Codes</option>
+                        <option value="form-codes">Form Codes</option>
+                        <option value="federal-waste-codes">Federal Waste Codes</option>
+                    </select>
+                </div>
+                <div class="col-3 d-flex justify-content-end">
+                    <button class="btn btn-primary">Fetch Lookup</button>
+                </div>
+            </div>
+        </form>
+        <div class="position-relative">
+            <textarea aria-label="Lookup Service Output" class="form-control" id="lookupOutput" readonly
+                      style="height: 200px;"></textarea>
+            <button class="position-absolute btn btn-secondary top-0 end-0 m-2 "
+                    onclick="copyToClipboard('lookupOutput')"
+            >Copy
+            </button>
+        </div>
     </div>
     <div class="my-3">
         <h2>Site Services</h2>
-        <div class="row d-flex align-items-end mb-3">
-            <div class="col-3">
-                <label for="siteServiceSelection">Select Site Service</label>
-                <select class="form-select" id="siteServiceSelection">
-                    <option value="getSite">Get Site</option>
-                    <option value="getSiteExists">Get Site Exists</option>
-                </select>
+        <form action="javascript:executeService(document.getElementById('siteService').value)">
+            <div class="row d-flex align-items-end mb-3">
+                <div class="col-3">
+                    <label for="siteService">Select Site Service</label>
+                    <select class="form-select" id="siteService">
+                        <option value="getSite">Get Site</option>
+                        <option value="getSiteExists">Get Site Exists</option>
+                    </select>
+                </div>
+                <div class="col-6">
+                    <label for="siteEpaId">Enter Site EPA ID</label>
+                    <input class="form-control" id="siteEpaId" required type="text"/>
+                </div>
+                <div class="col-3 d-flex justify-content-end">
+                    <button class="btn btn-primary" type="submit">Fetch Site</button>
+                </div>
             </div>
-            <div class="col-6">
-                <label for="siteEpaId">Enter Site EPA ID</label>
-                <input class="form-control" id="siteEpaId" type="text"/>
-            </div>
-            <div class="col-3 d-flex justify-content-end">
-                <button class="btn btn-primary" onclick="fetchSiteData()">Fetch Site Data</button>
-            </div>
+        </form>
+        <div class="position-relative">
+            <textarea aria-label="Site Service output" class="form-control" id="siteJsonOutput" readonly
+                      style="width: 100%; height: 200px;"></textarea>
+            <button class="position-absolute btn btn-secondary top-0 end-0 m-2" id="copyButton"
+                    onclick="copyToClipboard('siteJsonOutput')"
+            >Copy
+            </button>
         </div>
-        <textarea class="form-control" id="siteJsonOutput" style="width: 100%; height: 500px;"></textarea>
+    </div>
+</div>
+<div class="toast-container position-fixed bottom-0 end-0 m-3">
+    <div aria-atomic="true" aria-live="assertive" class="toast" data-bs-delay="2000" id="liveToast" role="alert">
+        <div class="toast-body">
+            <p class="font-monospace fw-bold mb-0">
+                Copied to clipboard
+            </p>
+        </div>
     </div>
 </div>
 </body>
 </html>
-<script>
-    async function fetchSiteData() {
-        const endpoint = document.getElementById('siteServiceSelection').value;
-        const epaId = document.getElementById('siteEpaId').value;
-        let url = `http://localhost:8080/api/site/${epaId}`;
-        if (endpoint === 'getSiteExists') {
-            url = `${url}/exists`;
+<script th:src="@{rcrainfoServices.js}"></script>
+<script th:inline="javascript">
+    /*<![CDATA[*/
+    const tokenExpiration = /*[[${tokenExpiration}]]*/ '2024-04-17T11:57:34.241Z';
+    startCountdown(tokenExpiration);
+    /*]]>*/
+
+    /**
+     * This function gathers input from the page/form and returns the appropriate service and the ID of the element
+     * where the data should be displayed. This function inherently represents the contract between the document and
+     * our javascript.
+     * @param serviceName
+     * @returns {{service: ((function(): Promise<undefined|any>)|*), outputElement: string}}
+     */
+    const sampleClientServiceFactory = (serviceName) => {
+        switch (serviceName) {
+            case 'getSiteExists':
+                const epaSiteId = document.getElementById('siteEpaId').value;
+                return {service: ApiClient.fetchSiteExists(epaSiteId), outputElement: 'siteJsonOutput'};
+            case 'getSite':
+                const epaId = document.getElementById('siteEpaId').value;
+                return {service: ApiClient.fetchSite(epaId), outputElement: 'siteJsonOutput'};
+            case 'lookup':
+                const lookupServiceName = document.getElementById('lookupService').value;
+                return {service: ApiClient.fetchLookup(lookupServiceName), outputElement: 'lookupOutput'};
+            default:
+                alert('There was an error, unrecognized service invoked');
         }
-        const response = await fetch(url);
-        const data = await response.json();
-        document.getElementById('siteJsonOutput').value = JSON.stringify(data, null, 2);
     }
 
-    async function fetchData() {
-        const endpoint = document.getElementById('endpoints').value;
-        const response = await fetch(`http://localhost:8080/api/lookup/${endpoint}`);
-        const data = await response.json();
-        document.getElementById('jsonOutput').value = JSON.stringify(data, null, 2);
+    /**
+     * Execute the service call (to our sample client's API, to RCRAInfo, and back if successful) and display the
+     * results in the appropriate element.
+     * @param serviceName
+     * @returns {Promise<void>}
+     */
+    const executeService = async (serviceName) => {
+        const factory = sampleClientServiceFactory(serviceName);
+        const data = await factory.service();
+        displayData(factory.outputElement, data);
+    }
+
+    const displayData = (elementId, data) => {
+        document.getElementById(elementId).value = JSON.stringify(data, null, 2);
     }
 </script>


### PR DESCRIPTION
Adds a simple UI to our sample client. 

The very simple UI makes request to the sample-client local backend which forwards the authenticated request to RCRAInfo. The RCRAInfo response is routed back to the sample client UI and displayed in a read only text box. Pretty simple, no frills. 

![image](https://github.com/USEPA/e-manifest/assets/43794491/aaada6b6-c1f8-45ce-8fb9-e0bb55c8a05b)
