### PR TITLE
1617 patch manifest methods do not send updates

### DIFF
--- a/emanifest-py/pyproject.toml
+++ b/emanifest-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "emanifest"
-version = "4.1.1"
+version = "4.1.2"
 description = "An API utility wrapper for accessing the e-Manifest hazardous waste tracking system maintained by the US Environmental Protection Agency"
 readme = "README.md"
 authors = [

--- a/emanifest-py/src/emanifest/client.py
+++ b/emanifest-py/src/emanifest/client.py
@@ -871,7 +871,7 @@ class RcrainfoClient(Session):
             dict: message of success or failure
         """
         endpoint = f"{self.base_url}v1/emanifest/manifest/patch-update/{mtn}"
-        return self.__rcra_request("PATCH", endpoint)
+        return self.__rcra_request("PATCH", endpoint, body)
 
     def patch_correct_manifest(self, mtn: str, body: dict) -> RcrainfoResponse:
         """
@@ -885,7 +885,7 @@ class RcrainfoClient(Session):
             dict: message of success or failure
         """
         endpoint = f"{self.base_url}v1/emanifest/manifest/patch-correct/{mtn}"
-        return self.__rcra_request("PATCH", endpoint)
+        return self.__rcra_request("PATCH", endpoint, body)
 
     def update_manifest(
         self, manifest_json: dict, zip_file: bytes = None


### PR DESCRIPTION
Increments package version to 4.1.2 and sends "body" parameter in patch-correct methods. Closes #1617 