### PR TITLE
test docs build 

### DIFF
--- a/.github/workflows/test_docs_build.yaml
+++ b/.github/workflows/test_docs_build.yaml
@@ -1,0 +1,38 @@
+name: "Test Docs Build"
+
+# This workflow builds and deploys the USEPA e-Manifest web service documentation
+# It will only deploy to GitHub if the repo is 'USEPA/e-manifest'
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+    paths:
+      - 'docs/**/*'
+  push:
+    paths:
+      - 'docs/**/*'
+  workflow_dispatch:
+
+env:
+  BOOK_DIRECTORY: ./docs
+  MDBOOK_VERSION: v0.4.37
+
+jobs:
+  build_docs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.BOOK_DIRECTORY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup mdBook
+        run: |
+          mkdir bin
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/${{env.MDBOOK_VERSION}}/mdbook-${{env.MDBOOK_VERSION}}-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
+
+      - name: Build Documentation
+        run: bin/mdbook build


### PR DESCRIPTION
adds a workflow to test to make sure the static site generator for the service documentation is able to build the docs before merging PRs. 