### PR TITLE
Better define dependencies

### DIFF
--- a/emanifest-py/pyproject.toml
+++ b/emanifest-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "emanifest"
-version = "4.1.3"
+version = "4.1.4"
 description = "An API utility wrapper for accessing the e-Manifest hazardous waste tracking system maintained by the US Environmental Protection Agency"
 readme = "README.md"
 authors = [
@@ -16,7 +16,7 @@ maintainers = [
 license = { text = "CCO 1.0" }
 requires-python = ">=3.10"
 dependencies = [
-    "requests<=2.27.0",
+    "requests~=2.0.0, <3.0.0",
     "requests-toolbelt<=1.0.0",
 ]
 

--- a/emanifest-py/requirements.txt
+++ b/emanifest-py/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.32.3
+requests~=2.30.0
 requests-toolbelt==1.0.0


### PR DESCRIPTION
loosen requests requirements to be compatible with our development dependency (responses) but less than 3. These are looser but better defined than we had before

increment patch version