### PR TITLE
Corrected ManifestReport JSON schema for manifest error response

### DIFF
--- a/Services-Information/Schema/crud-emanifest-return.json
+++ b/Services-Information/Schema/crud-emanifest-return.json
@@ -107,13 +107,13 @@
 				"tsdfReport": {
 					"$ref": "#/definitions/EntityReport"
 				},
-				"transportersReports": {
+				"transporterReports": {
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/EntityReport"
 					}
 				},
-				"wastesReports": {
+				"wasteReports": {
 					"type": "array",
 					"items": {
 						"$ref": "#/definitions/EntityReport"


### PR DESCRIPTION
The "ManifestReport" schema defines properties "transportersReports" and "wastesReports", however in production the properties are singular:  "transporterReports" and "wasteReports" respectively.